### PR TITLE
Introduce k8s config mode

### DIFF
--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -8,4 +8,4 @@ rules:
   verbs: ["get", "watch", "list"]
 - apiGroups: ["networking.istio.io"]
   resources: ["gateways", "serviceentries", "workloadentries", "destinationrules", "virtualservices"]
-  verbs: ["get", "create", "update"]
+  verbs: ["get", "list", "create", "update", "patch", "delete"]

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -6,3 +6,6 @@ rules:
 - apiGroups: [""]
   resources: ["services"]
   verbs: ["get", "watch", "list"]
+- apiGroups: ["networking.istio.io"]
+  resources: ["gateways", "serviceentries", "workloadentries", "destinationrules", "virtualservices"]
+  verbs: ["get", "create", "update"]

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
         args:
         - '--meshPeers={{ .Values.federation.meshPeers | toJson }}'
         - '--exportedServiceSet={{ .Values.federation.exportedServiceSet | toJson }}'
+        - '--configMode={{ .Values.federation.configMode | default "mcp" }}'
         env:
         - name: CONTROLLER_SERVICE_FQDN
           value: "{{ include "chart.name" . }}.{{ .Release.Namespace }}.svc.cluster.local"

--- a/cmd/federation-controller/main.go
+++ b/cmd/federation-controller/main.go
@@ -232,7 +232,7 @@ func main() {
 			log.Fatalf("Error running XDS server: %v", err)
 		}
 	} else if cfg.ConfigMode == config.ConfigModeK8s {
-		istioClient, err := istiokube.NewClient(istiokube.NewClientConfigForRestConfig(kubeConfig), "cluster-id")
+		istioClient, err := istiokube.NewClient(istiokube.NewClientConfigForRestConfig(kubeConfig), "")
 		if err != nil {
 			log.Fatalf("failed to create Istio client: %v", err)
 		}

--- a/internal/pkg/config/federation_config.go
+++ b/internal/pkg/config/federation_config.go
@@ -23,6 +23,7 @@ type Federation struct {
 	MeshPeers          MeshPeers
 	ExportedServiceSet ExportedServiceSet
 	ImportedServiceSet ImportedServiceSet
+	ConfigMode         ConfigMode
 }
 
 type MeshPeers struct {
@@ -104,3 +105,10 @@ type MatchExpressions struct {
 	Operator string   `yaml:"operator"`
 	Values   []string `yaml:"values"`
 }
+
+type ConfigMode string
+
+const (
+	ConfigModeMCP ConfigMode = "mcp"
+	ConfigModeK8s ConfigMode = "k8s"
+)

--- a/internal/pkg/istio/config_factory.go
+++ b/internal/pkg/istio/config_factory.go
@@ -150,8 +150,9 @@ func (cf *ConfigFactory) GetServiceEntries() ([]*v1alpha3.ServiceEntry, error) {
 			serviceEntries = append(serviceEntries, &v1alpha3.ServiceEntry{
 				ObjectMeta: metav1.ObjectMeta{
 					// TODO: add peer name to ensure uniqueness when more than 2 peers are connected
-					Name:      fmt.Sprintf("import_%s_%s", importedSvc.Name, importedSvc.Namespace),
+					Name:      fmt.Sprintf("import-%s-%s", importedSvc.Name, importedSvc.Namespace),
 					Namespace: cf.cfg.MeshPeers.Local.ControlPlane.Namespace,
+					Labels:    map[string]string{"federation.istio-ecosystem.io/peer": "todo"},
 				},
 				Spec: istionetv1alpha3.ServiceEntry{
 					Hosts:      []string{fmt.Sprintf("%s.%s.svc.cluster.local", importedSvc.Name, importedSvc.Namespace)},
@@ -186,8 +187,9 @@ func (cf *ConfigFactory) GetWorkloadEntries() ([]*v1alpha3.WorkloadEntry, error)
 			for idx, weSpec := range workloadEntrySpecs {
 				workloadEntries = append(workloadEntries, &v1alpha3.WorkloadEntry{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprintf("import_%s_%d", importedSvc.Name, idx),
+						Name:      fmt.Sprintf("import-%s-%d", importedSvc.Name, idx),
 						Namespace: importedSvc.Namespace,
+						Labels:    map[string]string{"federation.istio-ecosystem.io/peer": "todo"},
 					},
 					Spec: *weSpec.DeepCopy(),
 				})
@@ -236,6 +238,7 @@ func (cf *ConfigFactory) getServiceEntryForRemoteFederationController() *v1alpha
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "remote-federation-controller",
 			Namespace: cf.cfg.MeshPeers.Local.ControlPlane.Namespace,
+			Labels:    map[string]string{"federation.istio-ecosystem.io/peer": "todo"},
 		},
 		Spec: istionetv1alpha3.ServiceEntry{
 			Hosts: []string{fmt.Sprintf("remote-federation-controller.%s.svc.cluster.local", cf.cfg.MeshPeers.Local.ControlPlane.Namespace)},

--- a/internal/pkg/kube/destination_rule_reconciler.go
+++ b/internal/pkg/kube/destination_rule_reconciler.go
@@ -47,6 +47,9 @@ func (r *DestinationRuleReconciler) GetTypeUrl() string {
 
 func (r *DestinationRuleReconciler) Reconcile(ctx context.Context) error {
 	dr := r.cf.GetDestinationRules()
+	if dr == nil {
+		return nil
+	}
 
 	kind := "DestinationRule"
 	apiVersion := "networking.istio.io/v1alpha3"

--- a/internal/pkg/kube/destination_rule_reconciler.go
+++ b/internal/pkg/kube/destination_rule_reconciler.go
@@ -1,0 +1,55 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jewertow/federation/internal/pkg/istio"
+	"github.com/jewertow/federation/internal/pkg/xds"
+	"istio.io/istio/pkg/kube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ Reconciler = (*DestinationRuleReconciler)(nil)
+
+type DestinationRuleReconciler struct {
+	client kube.Client
+	cf     *istio.ConfigFactory
+}
+
+func NewDestinationRuleReconciler(client kube.Client, cf *istio.ConfigFactory) *DestinationRuleReconciler {
+	return &DestinationRuleReconciler{
+		client: client,
+		cf:     cf,
+	}
+}
+
+func (r *DestinationRuleReconciler) GetTypeUrl() string {
+	return xds.DestinationRuleTypeUrl
+}
+
+func (r *DestinationRuleReconciler) Reconcile(ctx context.Context) error {
+	dr := r.cf.GetDestinationRules()
+	createdDR, err := r.client.Istio().NetworkingV1alpha3().DestinationRules(dr.Namespace).Create(ctx, dr, metav1.CreateOptions{})
+	if client.IgnoreAlreadyExists(err) != nil {
+		return fmt.Errorf("failed to create destination rule: %v", err)
+	}
+	log.Infof("created destination rule: %v", createdDR)
+
+	return nil
+}

--- a/internal/pkg/kube/gateway_reconciler.go
+++ b/internal/pkg/kube/gateway_reconciler.go
@@ -1,0 +1,58 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jewertow/federation/internal/pkg/istio"
+	"github.com/jewertow/federation/internal/pkg/xds"
+	"istio.io/istio/pkg/kube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ Reconciler = (*GatewayResourceReconciler)(nil)
+
+type GatewayResourceReconciler struct {
+	client kube.Client
+	cf     *istio.ConfigFactory
+}
+
+func NewGatewayResourceReconciler(client kube.Client, cf *istio.ConfigFactory) *GatewayResourceReconciler {
+	return &GatewayResourceReconciler{
+		client: client,
+		cf:     cf,
+	}
+}
+
+func (r *GatewayResourceReconciler) GetTypeUrl() string {
+	return xds.GatewayTypeUrl
+}
+
+func (r *GatewayResourceReconciler) Reconcile(ctx context.Context) error {
+	gw, err := r.cf.GetIngressGateway()
+	if err != nil {
+		return fmt.Errorf("error generating ingress gateway: %v", err)
+	}
+	createdG, err := r.client.Istio().NetworkingV1alpha3().Gateways(gw.Namespace).Create(ctx, gw, metav1.CreateOptions{})
+	if client.IgnoreAlreadyExists(err) != nil {
+		return fmt.Errorf("failed to create ingress gateway: %v", err)
+	}
+	log.Infof("created ingress gateway: %v", createdG)
+
+	return nil
+}

--- a/internal/pkg/kube/reconciler.go
+++ b/internal/pkg/kube/reconciler.go
@@ -1,0 +1,27 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import "context"
+
+// Reconciler handles reconciliation of all resources of a K8s kind.
+type Reconciler interface {
+	// GetTypeUrl returns the K8s API URL for the supported resource type.
+	// An implementation can support only one resource type.
+	GetTypeUrl() string
+
+	// Reconcile all resources of the K8s resource type.
+	Reconcile(ctx context.Context) error
+}

--- a/internal/pkg/kube/reconciler_manager.go
+++ b/internal/pkg/kube/reconciler_manager.go
@@ -17,8 +17,9 @@ package kube
 import (
 	"context"
 
-	"github.com/jewertow/federation/internal/pkg/xds"
 	istiolog "istio.io/istio/pkg/log"
+
+	"github.com/openshift-service-mesh/federation/internal/pkg/xds"
 )
 
 var log = istiolog.RegisterScope("kube", "Kubernetes reconciler")

--- a/internal/pkg/kube/reconciler_manager.go
+++ b/internal/pkg/kube/reconciler_manager.go
@@ -1,0 +1,73 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+
+	"github.com/jewertow/federation/internal/pkg/xds"
+	istiolog "istio.io/istio/pkg/log"
+)
+
+var log = istiolog.RegisterScope("kube", "Kubernetes reconciler")
+
+type ReconcilerManager struct {
+	pushRequests <-chan xds.PushRequest
+	reconcilers  map[string]Reconciler
+}
+
+func NewReconcilerManager(pushRequests <-chan xds.PushRequest, reconcilers ...Reconciler) *ReconcilerManager {
+	reconcilerMap := make(map[string]Reconciler, len(reconcilers))
+	for _, r := range reconcilers {
+		reconcilerMap[r.GetTypeUrl()] = r
+	}
+
+	return &ReconcilerManager{
+		pushRequests: pushRequests,
+		reconcilers:  reconcilerMap,
+	}
+}
+
+func (rm *ReconcilerManager) ReconcileAll(ctx context.Context) error {
+	for _, r := range rm.reconcilers {
+		if err := r.Reconcile(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (rm *ReconcilerManager) Start(ctx context.Context) {
+
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			break loop
+
+		case pushRequest := <-rm.pushRequests:
+			log.Infof("[kube] Received push request: %v", pushRequest)
+
+			if r, ok := rm.reconcilers[pushRequest.TypeUrl]; !ok {
+				log.Infof("[kube] No reconciler present for type: %v", pushRequest.TypeUrl)
+			} else {
+				err := r.Reconcile(ctx)
+				if err != nil {
+					log.Errorf("[kube] Reconcile failed: %v", err)
+				}
+			}
+		}
+	}
+}

--- a/internal/pkg/kube/reconciler_manager.go
+++ b/internal/pkg/kube/reconciler_manager.go
@@ -59,14 +59,14 @@ loop:
 			break loop
 
 		case pushRequest := <-rm.pushRequests:
-			log.Infof("[kube] Received push request: %v", pushRequest)
+			log.Infof("Received push request: %v", pushRequest)
 
 			if r, ok := rm.reconcilers[pushRequest.TypeUrl]; !ok {
-				log.Infof("[kube] No reconciler present for type: %v", pushRequest.TypeUrl)
+				log.Infof("No reconciler present for type: %v", pushRequest.TypeUrl)
 			} else {
 				err := r.Reconcile(ctx)
 				if err != nil {
-					log.Errorf("[kube] Reconcile failed: %v", err)
+					log.Errorf("Reconcile failed: %v", err)
 				}
 			}
 		}

--- a/internal/pkg/kube/service_entry_reconciler.go
+++ b/internal/pkg/kube/service_entry_reconciler.go
@@ -70,12 +70,6 @@ func (r *ServiceEntryReconciler) Reconcile(ctx context.Context) error {
 	oldServiceEntriesMap := make(map[types.NamespacedName]*v1alpha3.ServiceEntry, len(oldServiceEntries.Items))
 	for _, se := range oldServiceEntries.Items {
 		oldServiceEntriesMap[types.NamespacedName{Namespace: se.Namespace, Name: se.Name}] = se
-
-		log.Infof("******* oldSEKey: %v, oldSe: %v", oldServiceEntriesMap[types.NamespacedName{Namespace: se.Namespace, Name: se.Name}], &se.Spec)
-	}
-
-	for k, v := range serviceEntriesMap {
-		log.Infof("******* newSEKey: %v, newSe: %v", k, &v.Spec)
 	}
 
 	kind := "ServiceEntry"

--- a/internal/pkg/kube/service_entry_reconciler.go
+++ b/internal/pkg/kube/service_entry_reconciler.go
@@ -1,0 +1,60 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jewertow/federation/internal/pkg/istio"
+	"github.com/jewertow/federation/internal/pkg/xds"
+	"istio.io/istio/pkg/kube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ Reconciler = (*ServiceEntryReconciler)(nil)
+
+type ServiceEntryReconciler struct {
+	client kube.Client
+	cf     *istio.ConfigFactory
+}
+
+func NewServiceEntryReconciler(client kube.Client, cf *istio.ConfigFactory) *ServiceEntryReconciler {
+	return &ServiceEntryReconciler{
+		client: client,
+		cf:     cf,
+	}
+}
+
+func (r *ServiceEntryReconciler) GetTypeUrl() string {
+	return xds.ServiceEntryTypeUrl
+}
+
+func (r *ServiceEntryReconciler) Reconcile(ctx context.Context) error {
+	serviceEntries, err := r.cf.GetServiceEntries()
+	if err != nil {
+		return fmt.Errorf("error generating service entries: %v", err)
+	}
+
+	for _, se := range serviceEntries {
+		createdSE, err := r.client.Istio().NetworkingV1alpha3().ServiceEntries(se.Namespace).Create(ctx, se, metav1.CreateOptions{})
+		if client.IgnoreAlreadyExists(err) != nil {
+			return fmt.Errorf("failed to create service entry: %v", err)
+		}
+		log.Infof("created service entry: %v", createdSE)
+	}
+	return nil
+}

--- a/internal/pkg/kube/virtual_service_reconciler.go
+++ b/internal/pkg/kube/virtual_service_reconciler.go
@@ -1,0 +1,55 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jewertow/federation/internal/pkg/istio"
+	"github.com/jewertow/federation/internal/pkg/xds"
+	"istio.io/istio/pkg/kube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ Reconciler = (*VirtualServiceReconciler)(nil)
+
+type VirtualServiceReconciler struct {
+	client kube.Client
+	cf     *istio.ConfigFactory
+}
+
+func NewVirtualServiceReconciler(client kube.Client, cf *istio.ConfigFactory) *VirtualServiceReconciler {
+	return &VirtualServiceReconciler{
+		client: client,
+		cf:     cf,
+	}
+}
+
+func (r *VirtualServiceReconciler) GetTypeUrl() string {
+	return xds.VirtualServiceTypeUrl
+}
+
+func (r *VirtualServiceReconciler) Reconcile(ctx context.Context) error {
+	vs := r.cf.GetVirtualServices()
+	createdVS, err := r.client.Istio().NetworkingV1alpha3().VirtualServices(vs.Namespace).Create(ctx, vs, metav1.CreateOptions{})
+	if client.IgnoreAlreadyExists(err) != nil {
+		return fmt.Errorf("failed to create virtual service: %v", err)
+	}
+	log.Infof("created virtual service: %v", createdVS)
+
+	return nil
+}

--- a/internal/pkg/kube/workload_entry_reconciler.go
+++ b/internal/pkg/kube/workload_entry_reconciler.go
@@ -1,0 +1,60 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jewertow/federation/internal/pkg/istio"
+	"github.com/jewertow/federation/internal/pkg/xds"
+	"istio.io/istio/pkg/kube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ Reconciler = (*WorkloadEntryReconciler)(nil)
+
+type WorkloadEntryReconciler struct {
+	client kube.Client
+	cf     *istio.ConfigFactory
+}
+
+func NewWorkloadEntryReconciler(client kube.Client, cf *istio.ConfigFactory) *WorkloadEntryReconciler {
+	return &WorkloadEntryReconciler{
+		client: client,
+		cf:     cf,
+	}
+}
+
+func (r *WorkloadEntryReconciler) GetTypeUrl() string {
+	return xds.WorkloadEntryTypeUrl
+}
+
+func (r *WorkloadEntryReconciler) Reconcile(ctx context.Context) error {
+	workloadEntries, err := r.cf.GetWorkloadEntries()
+	if err != nil {
+		return fmt.Errorf("error generating workload entries: %v", err)
+	}
+
+	for _, we := range workloadEntries {
+		createdWE, err := r.client.Istio().NetworkingV1alpha3().WorkloadEntries(we.Namespace).Create(ctx, we, metav1.CreateOptions{})
+		if client.IgnoreAlreadyExists(err) != nil {
+			return fmt.Errorf("failed to create workload entry: %v", err)
+		}
+		log.Infof("created service entry: %v", createdWE)
+	}
+	return nil
+}

--- a/internal/pkg/kube/workload_entry_reconciler.go
+++ b/internal/pkg/kube/workload_entry_reconciler.go
@@ -17,12 +17,18 @@ package kube
 import (
 	"context"
 	"fmt"
+	"reflect"
 
-	"github.com/jewertow/federation/internal/pkg/istio"
-	"github.com/jewertow/federation/internal/pkg/xds"
+	"istio.io/client-go/pkg/apis/networking/v1alpha3"
+	applyconfigurationv1 "istio.io/client-go/pkg/applyconfiguration/meta/v1"
+	v1alpha4 "istio.io/client-go/pkg/applyconfiguration/networking/v1alpha3"
 	"istio.io/istio/pkg/kube"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/openshift-service-mesh/federation/internal/pkg/istio"
+	"github.com/openshift-service-mesh/federation/internal/pkg/xds"
 )
 
 var _ Reconciler = (*WorkloadEntryReconciler)(nil)
@@ -48,13 +54,69 @@ func (r *WorkloadEntryReconciler) Reconcile(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error generating workload entries: %v", err)
 	}
-
+	workloadEntriesMap := make(map[types.NamespacedName]*v1alpha3.WorkloadEntry, len(workloadEntries))
 	for _, we := range workloadEntries {
-		createdWE, err := r.client.Istio().NetworkingV1alpha3().WorkloadEntries(we.Namespace).Create(ctx, we, metav1.CreateOptions{})
-		if client.IgnoreAlreadyExists(err) != nil {
-			return fmt.Errorf("failed to create workload entry: %v", err)
-		}
-		log.Infof("created service entry: %v", createdWE)
+		workloadEntriesMap[types.NamespacedName{Namespace: we.Namespace, Name: we.Name}] = we
 	}
+
+	oldWorkloadEntries, err := r.client.Istio().NetworkingV1alpha3().WorkloadEntries(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+		LabelSelector: metav1.FormatLabelSelector(&metav1.LabelSelector{
+			MatchLabels: map[string]string{"federation.istio-ecosystem.io/peer": "todo"},
+		}),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list workload entries: %v", err)
+	}
+	oldWorkloadEntriesMap := make(map[types.NamespacedName]*v1alpha3.WorkloadEntry, len(oldWorkloadEntries.Items))
+	for _, we := range oldWorkloadEntries.Items {
+		oldWorkloadEntriesMap[types.NamespacedName{Namespace: we.Namespace, Name: we.Name}] = we
+	}
+
+	kind := "WorkloadEntry"
+	apiVersion := "networking.istio.io/v1alpha3"
+	for k, we := range workloadEntriesMap {
+		oldWE, ok := oldWorkloadEntriesMap[k]
+		if !ok || !reflect.DeepEqual(&oldWE.Spec, &we.Spec) {
+			// Workload entry does not currently exist or requires update
+			newWE, err := r.client.Istio().NetworkingV1alpha3().WorkloadEntries(we.GetNamespace()).Apply(ctx,
+				&v1alpha4.WorkloadEntryApplyConfiguration{
+					TypeMetaApplyConfiguration: applyconfigurationv1.TypeMetaApplyConfiguration{
+						Kind:       &kind,
+						APIVersion: &apiVersion,
+					},
+					ObjectMetaApplyConfiguration: &applyconfigurationv1.ObjectMetaApplyConfiguration{
+						Name:      &we.Name,
+						Namespace: &we.Namespace,
+						Labels:    we.Labels,
+					},
+					Spec:   &we.Spec,
+					Status: nil,
+				},
+				metav1.ApplyOptions{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       kind,
+						APIVersion: apiVersion,
+					},
+					Force:        true,
+					FieldManager: "federation-controller",
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("failed to apply workload entry: %v", err)
+			}
+			log.Infof("Applied workload entry: %v", newWE)
+		}
+	}
+
+	for k, oldWE := range oldWorkloadEntriesMap {
+		if _, ok := workloadEntriesMap[k]; !ok {
+			err := r.client.Istio().NetworkingV1alpha3().WorkloadEntries(oldWE.GetNamespace()).Delete(ctx, oldWE.GetName(), metav1.DeleteOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return fmt.Errorf("failed to delete old workload entry: %v", err)
+			}
+			log.Infof("Deleted workload entry: %v", oldWE)
+		}
+	}
+
 	return nil
 }

--- a/internal/pkg/mcp/service_entry_generator_test.go
+++ b/internal/pkg/mcp/service_entry_generator_test.go
@@ -139,7 +139,7 @@ func TestServiceEntryGenerator(t *testing.T) {
 		expectedIstioConfigs: []*istiocfg.Config{
 			{
 				Meta: istiocfg.Meta{
-					Name:      "import_a_ns1",
+					Name:      "import-a-ns1",
 					Namespace: "istio-system",
 				},
 				Spec: &istionetv1alpha3.ServiceEntry{
@@ -155,7 +155,7 @@ func TestServiceEntryGenerator(t *testing.T) {
 			},
 			{
 				Meta: istiocfg.Meta{
-					Name:      "import_a_ns2",
+					Name:      "import-a-ns2",
 					Namespace: "istio-system",
 				},
 				Spec: &istionetv1alpha3.ServiceEntry{
@@ -206,7 +206,7 @@ func TestServiceEntryGenerator(t *testing.T) {
 		expectedIstioConfigs: []*istiocfg.Config{
 			{
 				Meta: istiocfg.Meta{
-					Name:      "import_a_ns1",
+					Name:      "import-a-ns1",
 					Namespace: "istio-system",
 				},
 				Spec: &istionetv1alpha3.ServiceEntry{

--- a/internal/pkg/mcp/workload_entry_generator_test.go
+++ b/internal/pkg/mcp/workload_entry_generator_test.go
@@ -76,25 +76,25 @@ func TestWorkloadEntryGenerator(t *testing.T) {
 		}},
 		expectedIstioConfigs: []*istiocfg.Config{{
 			Meta: istiocfg.Meta{
-				Name:      "import_a_0",
+				Name:      "import-a-0",
 				Namespace: "ns1",
 			},
 			Spec: buildWorkloadEntry("192.168.0.1"),
 		}, {
 			Meta: istiocfg.Meta{
-				Name:      "import_a_1",
+				Name:      "import-a-1",
 				Namespace: "ns1",
 			},
 			Spec: buildWorkloadEntry("192.168.0.2"),
 		}, {
 			Meta: istiocfg.Meta{
-				Name:      "import_a_0",
+				Name:      "import-a-0",
 				Namespace: "ns2",
 			},
 			Spec: buildWorkloadEntry("192.168.0.1"),
 		}, {
 			Meta: istiocfg.Meta{
-				Name:      "import_a_1",
+				Name:      "import-a-1",
 				Namespace: "ns2",
 			},
 			Spec: buildWorkloadEntry("192.168.0.2"),


### PR DESCRIPTION
Closes #50

Current limitations:
1. Resources are not cleaned up when controller stops. We will need to add an ownerReference to resources so kube can garbage collect them.
2. Reconcile is not triggered when a user manually updates a resource managed by federation. (we will need an informer and handler similar to [this](https://github.com/openshift-service-mesh/federation/blob/master/cmd/federation-controller/main.go#L149))
3. Reconcilers GET and LIST resources by querying kube-apiserver. We should have a cached lister [similar to this](https://github.com/openshift-service-mesh/federation/blob/master/cmd/federation-controller/main.go#L149) for Istio resources as an optimisation.