### PR TITLE
Fix finding IPv4 subnets assigned to KinD clusters

### DIFF
--- a/test/scripts/lib.sh
+++ b/test/scripts/lib.sh
@@ -13,8 +13,8 @@ function install_metallb() {
   kubectl --kubeconfig="$ROOT/$cluster.kubeconfig" apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml
   kubectl --kubeconfig="$ROOT/$cluster.kubeconfig" wait -n metallb-system pod --timeout=120s -l app=metallb --for=condition=Ready
 
-  docker_kind_subnet="$(docker inspect kind | jq '.[0].IPAM.Config[0].Subnet' -r)"
-  cidr=$(python3 "$ROOT/scripts/find_smaller_subnets.py" --network "$docker_kind_subnet" --region "$cluster")
+  docker_kind_ipv4_subnet="$(docker inspect kind | jq '.[0].IPAM.Config' -r | jq -r '.[] | select(.Subnet | test("^[0-9]+\\.")) | .Subnet')"
+  cidr=$(python3 "$ROOT/scripts/find_smaller_subnets.py" --network "$docker_kind_ipv4_subnet" --region "$cluster")
 
   echo '
 apiVersion: metallb.io/v1beta1


### PR DESCRIPTION
Currently, we do not support east-west gateways with IPv6 address, and the KinD provisioner script was not checking which subnet it gets from the container config, so the [CI](https://github.com/openshift/release/pull/56927) checks fail due to wrong IP address pool:
```
++ docker inspect kind
++ jq '.[0].IPAM.Config[0].Subnet' -r
+ docker_kind_subnet=fc00:f853:ccd:e793::/64
++ python3 /work/test/scripts/find_smaller_subnets.py --network fc00:f853:ccd:e793::/64 --region west
+ cidr=fc00:f853:ccd:e793:4000::/66
+ echo '
apiVersion: metallb.io/v1beta1
kind: IPAddressPool
metadata:
  name: default-pool
  namespace: metallb-system
spec:
  addresses:
  - fc00:f853:ccd:e793:4000::/66
  avoidBuggyIPs: true
---
apiVersion: metallb.io/v1beta1
kind: L2Advertisement
metadata:
  name: default-l2
  namespace: metallb-system
spec:
  ipAddressPools:
  - default-pool
'
...
2024-10-04T05:16:28.358314Z	info	tf	=== DONE: Building clusters ===
2024-10-04T05:16:28.358328Z	info	tf	=== BEGIN: Setup: 'test_e2e' ===
2024-10-04T05:16:34.908807Z	error	tf	Test setup error: could not get IPs from remote federation-controller: no load balancer IP found for service istio-eastwestgateway/istio-system in cluster cluster-1
2024-10-04T05:16:34.908912Z	info	tf	=== FAILED: Setup: 'test_e2e' (could not get IPs from remote federation-controller: no load balancer IP found for service istio-eastwestgateway/istio-system in cluster cluster-1) ===
2024-10-04T05:16:34.908938Z	error	tf	Exiting due to setup failure: could not get IPs from remote federation-controller: no load balancer IP found for service istio-eastwestgateway/istio-system in cluster cluster-1
FAIL	github.com/jewertow/federation/test/e2e	6.626s
```