### PR TITLE
test: fix flaky test case that checks if a hostname is unreachable

### DIFF
--- a/test/e2e/traffic_test.go
+++ b/test/e2e/traffic_test.go
@@ -69,12 +69,15 @@ func TestTraffic(t *testing.T) {
 		})
 
 		ctx.NewSubTest("requests to c should fail").Run(func(ctx framework.TestContext) {
-			a[0].CallOrFail(t, echo.CallOptions{
+			res, err := a[0].Call(echo.CallOptions{
 				Address: fmt.Sprintf("c.%s.svc.cluster.local", appNs.Name()),
 				Port:    ports.HTTP,
-				Check:   check.Status(503),
+				Check:   check.Error(),
 				Timeout: 1 * time.Second,
 			})
+			if err == nil || res.Responses.Len() != 0 {
+				t.Fatalf("the request did not fail and got the following response: %v", res)
+			}
 		})
 
 		if err := exportService(ctx.Clusters().GetByName(westClusterName), "b", appNs.Name()); err != nil {

--- a/test/e2e/traffic_test.go
+++ b/test/e2e/traffic_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"google.golang.org/grpc/codes"
 	"istio.io/istio/pkg/test/echo/common/scheme"
@@ -72,8 +71,6 @@ func TestTraffic(t *testing.T) {
 			res, err := a[0].Call(echo.CallOptions{
 				Address: fmt.Sprintf("c.%s.svc.cluster.local", appNs.Name()),
 				Port:    ports.HTTP,
-				Check:   check.Error(),
-				Timeout: 1 * time.Second,
 			})
 			if err == nil || res.Responses.Len() != 0 {
 				t.Fatalf("the request did not fail and got the following response: %v", res)


### PR DESCRIPTION
The test case "requests to c should fail" sometimes fails, because it does not receive any response, but it expects to get an error. The hostname should be unreachable, so missing responses are also correct in this case, and this behavior may be caused by a DNS response delay.