### PR TITLE
feat(build): configurable container builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,15 @@ build:
 test: build
 	go test ./...
 
+CONTAINER_CLI ?= docker
+
 .PHONY: docker-build
 docker-build: build
-	docker build -t $(HUB)/federation-controller:$(TAG) -f build/Dockerfile .
+	$(CONTAINER_CLI) build -t $(HUB)/federation-controller:$(TAG) -f build/Dockerfile .
 
 .PHONY: docker-push
 docker-push:
-	docker push $(HUB)/federation-controller:$(TAG)
+	$(CONTAINER_CLI) push $(HUB)/federation-controller:$(TAG)
 
 .PHONY: docker
 docker: docker-build docker-push


### PR DESCRIPTION
Our build process relies on `docker` client to build and push images. In most cases it is all we need, but we can easily open it up for other container tools to be used instead, for example `podman`.

To make it possible, `CONTAINER_CLI` variable is introduced that can be configured when running the build. Named is aligned with the Istio project.

This can be used in a few different ways during the build process:

```sh
make docker -e CONTAINER_CLI=podman
CONTAINER_CLI=podman make docker
export CONTAINER_CLI=podman && make docker
```