### PR TITLE
chore(errors): wraps errors using %w

### DIFF
--- a/internal/pkg/fds/exported_service_generator.go
+++ b/internal/pkg/fds/exported_service_generator.go
@@ -53,7 +53,7 @@ func (g *ExportedServicesGenerator) GenerateResponse() ([]*anypb.Any, error) {
 		matchExported := labels.SelectorFromSet(exportLabelSelector.MatchLabels)
 		services, err := g.serviceLister.List(matchExported)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list services: %v", err)
+			return nil, fmt.Errorf("failed to list services: %w", err)
 		}
 		for _, svc := range services {
 			var ports []*v1alpha1.ServicePort

--- a/internal/pkg/fds/import_handler.go
+++ b/internal/pkg/fds/import_handler.go
@@ -44,7 +44,7 @@ func (h *ImportedServiceHandler) Handle(resources []*anypb.Any) error {
 	for _, res := range resources {
 		exportedService := &v1alpha1.ExportedService{}
 		if err := proto.Unmarshal(res.Value, exportedService); err != nil {
-			return fmt.Errorf("unable to unmarshal exported service: %v", err)
+			return fmt.Errorf("unable to unmarshal exported service: %w", err)
 		}
 		// TODO: replace with full validation that returns an error on invalid request
 		if exportedService.Name == "" || exportedService.Namespace == "" {

--- a/internal/pkg/istio/config_factory.go
+++ b/internal/pkg/istio/config_factory.go
@@ -99,7 +99,7 @@ func (cf *ConfigFactory) GetIngressGateway() (*v1alpha3.Gateway, error) {
 		matchLabels := labels.SelectorFromSet(exportLabelSelector.MatchLabels)
 		services, err := cf.serviceLister.List(matchLabels)
 		if err != nil {
-			return nil, fmt.Errorf("error listing services (selector=%s): %v", matchLabels, err)
+			return nil, fmt.Errorf("error listing services (selector=%s): %w", matchLabels, err)
 		}
 		for _, svc := range services {
 			hosts = append(hosts, fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace))
@@ -135,7 +135,7 @@ func (cf *ConfigFactory) GetServiceEntries() ([]*v1alpha3.ServiceEntry, error) {
 		_, err := cf.serviceLister.Services(importedSvc.Namespace).Get(importedSvc.Name)
 		if err != nil {
 			if !errors.IsNotFound(err) {
-				return nil, fmt.Errorf("failed to get Service %s/%s: %v", importedSvc.Name, importedSvc.Namespace, err)
+				return nil, fmt.Errorf("failed to get Service %s/%s: %w", importedSvc.Name, importedSvc.Namespace, err)
 			}
 			// Service doesn't exist - create ServiceEntry.
 			var ports []*istionetv1alpha3.ServicePort
@@ -179,7 +179,7 @@ func (cf *ConfigFactory) GetWorkloadEntries() ([]*v1alpha3.WorkloadEntry, error)
 		_, err := cf.serviceLister.Services(importedSvc.Namespace).Get(importedSvc.Name)
 		if err != nil {
 			if !errors.IsNotFound(err) {
-				return nil, fmt.Errorf("failed to get Service %s/%s: %v", importedSvc.Name, importedSvc.Namespace, err)
+				return nil, fmt.Errorf("failed to get Service %s/%s: %w", importedSvc.Name, importedSvc.Namespace, err)
 			}
 		} else {
 			// Service already exists - create WorkloadEntries.

--- a/internal/pkg/kube/destination_rule_reconciler.go
+++ b/internal/pkg/kube/destination_rule_reconciler.go
@@ -73,7 +73,7 @@ func (r *DestinationRuleReconciler) Reconcile(ctx context.Context) error {
 		FieldManager: "federation-controller",
 	})
 	if err != nil {
-		return fmt.Errorf("failed to apply destination rule: %v", err)
+		return fmt.Errorf("failed to apply destination rule: %w", err)
 	}
 	log.Infof("Applied destination rule: %v", newDR)
 

--- a/internal/pkg/kube/gateway_reconciler.go
+++ b/internal/pkg/kube/gateway_reconciler.go
@@ -48,7 +48,7 @@ func (r *GatewayResourceReconciler) GetTypeUrl() string {
 func (r *GatewayResourceReconciler) Reconcile(ctx context.Context) error {
 	gw, err := r.cf.GetIngressGateway()
 	if err != nil {
-		return fmt.Errorf("error generating ingress gateway: %v", err)
+		return fmt.Errorf("error generating ingress gateway: %w", err)
 	}
 
 	kind := "Gateway"
@@ -73,7 +73,7 @@ func (r *GatewayResourceReconciler) Reconcile(ctx context.Context) error {
 		FieldManager: "federation-controller",
 	})
 	if err != nil {
-		return fmt.Errorf("error applying ingress gateway: %v", err)
+		return fmt.Errorf("error applying ingress gateway: %w", err)
 	}
 	log.Infof("Applied ingress gateway: %v", newGW)
 

--- a/internal/pkg/kube/service_entry_reconciler.go
+++ b/internal/pkg/kube/service_entry_reconciler.go
@@ -52,7 +52,7 @@ func (r *ServiceEntryReconciler) GetTypeUrl() string {
 func (r *ServiceEntryReconciler) Reconcile(ctx context.Context) error {
 	serviceEntries, err := r.cf.GetServiceEntries()
 	if err != nil {
-		return fmt.Errorf("error generating service entries: %v", err)
+		return fmt.Errorf("error generating service entries: %w", err)
 	}
 	serviceEntriesMap := make(map[types.NamespacedName]*v1alpha3.ServiceEntry, len(serviceEntries))
 	for _, se := range serviceEntries {
@@ -65,7 +65,7 @@ func (r *ServiceEntryReconciler) Reconcile(ctx context.Context) error {
 		}),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to list service entries: %v", err)
+		return fmt.Errorf("failed to list service entries: %w", err)
 	}
 	oldServiceEntriesMap := make(map[types.NamespacedName]*v1alpha3.ServiceEntry, len(oldServiceEntries.Items))
 	for _, se := range oldServiceEntries.Items {
@@ -101,7 +101,7 @@ func (r *ServiceEntryReconciler) Reconcile(ctx context.Context) error {
 				},
 			)
 			if err != nil {
-				return fmt.Errorf("failed to apply service entry: %v", err)
+				return fmt.Errorf("failed to apply service entry: %w", err)
 			}
 			log.Infof("Applied service entry: %v", newSE)
 		}
@@ -111,7 +111,7 @@ func (r *ServiceEntryReconciler) Reconcile(ctx context.Context) error {
 		if _, ok := serviceEntriesMap[k]; !ok {
 			err := r.client.Istio().NetworkingV1alpha3().ServiceEntries(oldSE.GetNamespace()).Delete(ctx, oldSE.GetName(), metav1.DeleteOptions{})
 			if err != nil && !errors.IsNotFound(err) {
-				return fmt.Errorf("failed to delete old service entry: %v", err)
+				return fmt.Errorf("failed to delete old service entry: %w", err)
 			}
 			log.Infof("Deleted service entry: %v", oldSE)
 		}

--- a/internal/pkg/kube/virtual_service_reconciler.go
+++ b/internal/pkg/kube/virtual_service_reconciler.go
@@ -70,7 +70,7 @@ func (r *VirtualServiceReconciler) Reconcile(ctx context.Context) error {
 		FieldManager: "federation-controller",
 	})
 	if err != nil {
-		return fmt.Errorf("error applying virtual service: %v", err)
+		return fmt.Errorf("error applying virtual service: %w", err)
 	}
 	log.Infof("Applied virtual service: %v", newVS)
 

--- a/internal/pkg/kube/workload_entry_reconciler.go
+++ b/internal/pkg/kube/workload_entry_reconciler.go
@@ -52,7 +52,7 @@ func (r *WorkloadEntryReconciler) GetTypeUrl() string {
 func (r *WorkloadEntryReconciler) Reconcile(ctx context.Context) error {
 	workloadEntries, err := r.cf.GetWorkloadEntries()
 	if err != nil {
-		return fmt.Errorf("error generating workload entries: %v", err)
+		return fmt.Errorf("error generating workload entries: %w", err)
 	}
 	workloadEntriesMap := make(map[types.NamespacedName]*v1alpha3.WorkloadEntry, len(workloadEntries))
 	for _, we := range workloadEntries {
@@ -65,7 +65,7 @@ func (r *WorkloadEntryReconciler) Reconcile(ctx context.Context) error {
 		}),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to list workload entries: %v", err)
+		return fmt.Errorf("failed to list workload entries: %w", err)
 	}
 	oldWorkloadEntriesMap := make(map[types.NamespacedName]*v1alpha3.WorkloadEntry, len(oldWorkloadEntries.Items))
 	for _, we := range oldWorkloadEntries.Items {
@@ -102,7 +102,7 @@ func (r *WorkloadEntryReconciler) Reconcile(ctx context.Context) error {
 				},
 			)
 			if err != nil {
-				return fmt.Errorf("failed to apply workload entry: %v", err)
+				return fmt.Errorf("failed to apply workload entry: %w", err)
 			}
 			log.Infof("Applied workload entry: %v", newWE)
 		}
@@ -112,7 +112,7 @@ func (r *WorkloadEntryReconciler) Reconcile(ctx context.Context) error {
 		if _, ok := workloadEntriesMap[k]; !ok {
 			err := r.client.Istio().NetworkingV1alpha3().WorkloadEntries(oldWE.GetNamespace()).Delete(ctx, oldWE.GetName(), metav1.DeleteOptions{})
 			if err != nil && !errors.IsNotFound(err) {
-				return fmt.Errorf("failed to delete old workload entry: %v", err)
+				return fmt.Errorf("failed to delete old workload entry: %w", err)
 			}
 			log.Infof("Deleted workload entry: %v", oldWE)
 		}

--- a/internal/pkg/mcp/gateway_generator.go
+++ b/internal/pkg/mcp/gateway_generator.go
@@ -45,7 +45,7 @@ func (g *GatewayResourceGenerator) GetTypeUrl() string {
 func (g *GatewayResourceGenerator) GenerateResponse() ([]*anypb.Any, error) {
 	gw, err := g.cf.GetIngressGateway()
 	if err != nil {
-		return nil, fmt.Errorf("error generating ingress gateway: %v", err)
+		return nil, fmt.Errorf("error generating ingress gateway: %w", err)
 	}
 	if gw == nil {
 		return nil, nil

--- a/internal/pkg/mcp/service_entry_generator.go
+++ b/internal/pkg/mcp/service_entry_generator.go
@@ -42,7 +42,7 @@ func (s *ServiceEntryGenerator) GetTypeUrl() string {
 func (s *ServiceEntryGenerator) GenerateResponse() ([]*anypb.Any, error) {
 	serviceEntries, err := s.istioConfigFactory.GetServiceEntries()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate service entries: %v", err)
+		return nil, fmt.Errorf("failed to generate service entries: %w", err)
 	}
 
 	var serviceEntryConfigs []*istioconfig.Config

--- a/internal/pkg/mcp/workload_entry_generator.go
+++ b/internal/pkg/mcp/workload_entry_generator.go
@@ -42,7 +42,7 @@ func (s *WorkloadEntryGenerator) GetTypeUrl() string {
 func (s *WorkloadEntryGenerator) GenerateResponse() ([]*anypb.Any, error) {
 	workloadEntries, err := s.istioConfigFactory.GetWorkloadEntries()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate workload entries: %v", err)
+		return nil, fmt.Errorf("failed to generate workload entries: %w", err)
 	}
 
 	var workloadEntryConfigs []*istioconfig.Config

--- a/internal/pkg/xds/adsc/adsc.go
+++ b/internal/pkg/xds/adsc/adsc.go
@@ -103,7 +103,7 @@ func (a *ADSC) dial() error {
 		}),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to establish connection to the ADS server %s: %v", a.cfg.DiscoveryAddr, err)
+		return fmt.Errorf("failed to establish connection to the ADS server %s: %w", a.cfg.DiscoveryAddr, err)
 	}
 	return nil
 }

--- a/test/e2e/common/setup.go
+++ b/test/e2e/common/setup.go
@@ -304,7 +304,7 @@ func RemoveServiceFromClusters(name string, ns namespace.Getter, targetClusterNa
 		for _, targetClusterName := range targetClusterNames {
 			targetCluster := ctx.Clusters().GetByName(targetClusterName)
 			if err := targetCluster.Kube().CoreV1().Services(ns.Get().Name()).Delete(context.Background(), name, v1.DeleteOptions{}); err != nil {
-				return fmt.Errorf("failed to delete Service %s/%s from cluster %s: %v", name, ns.Get().Name(), targetCluster.Name(), err)
+				return fmt.Errorf("failed to delete Service %s/%s from cluster %s: %w", name, ns.Get().Name(), targetCluster.Name(), err)
 			}
 		}
 		return nil

--- a/test/e2e/common/traffic_tests.go
+++ b/test/e2e/common/traffic_tests.go
@@ -161,16 +161,16 @@ func exportService(c cluster.Cluster, svcName, svcNs string) error {
 	if err := retry.UntilSuccess(func() error {
 		svc, err := c.Kube().CoreV1().Services(svcNs).Get(context.Background(), svcName, v1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to get service %s/%s: %v", svcNs, svcName, err)
+			return fmt.Errorf("failed to get service %s/%s: %w", svcNs, svcName, err)
 		}
 		svc.Labels["export-service"] = "true"
 		_, err = c.Kube().CoreV1().Services(svcNs).Update(context.Background(), svc, v1.UpdateOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to update service %s/%s: %v", svcNs, svcName, err)
+			return fmt.Errorf("failed to update service %s/%s: %w", svcNs, svcName, err)
 		}
 		return nil
 	}); err != nil {
-		return fmt.Errorf("failed to export service %s/%s: %v", svcNs, svcName, err)
+		return fmt.Errorf("failed to export service %s/%s: %w", svcNs, svcName, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Instead of printing a string representation of an error using `%v`, we can wrap it with `%w`. This makes handling and debugging it easier.

Quick find-replace to wrap errors using `%w` instead of `%v` when using `fmt.Errorf`.

Discussed in #61.