### PR TITLE
fix(make): ensures test image is built for kind setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,13 @@ proto:
 	protoc --proto_path=$(PROTO_DIR) --go_out=$(OUT_DIR) --go-grpc_out=$(OUT_DIR) --golang-deepcopy_out=:$(OUT_DIR) $(PROTO_DIR)/**/*.proto
 
 .PHONY: kind-clusters
-kind-clusters:
+kind-clusters: build-test-image
 	bash test/scripts/kind_provisioner.sh $(ISTIO_VERSION)
 
 .PHONY: build-test-image
-ifeq ($(USE_LOCAL_IMAGE),true)
 build-test-image:
-	TAG=test $(MAKE) docker-build
+ifeq ($(USE_LOCAL_IMAGE), true)
+	$(MAKE) docker-build -e TAG=test
 endif
 
 .PHONY: e2e


### PR DESCRIPTION
Executing `make kind-clusters` on a clean environment results with the error:

```sh
+ for cluster_name in "east" "west"
+ kind load docker-image --nodes east-control-plane --name east quay.io/maistra-dev/federation-controller:test
ERROR: image: "quay.io/maistra-dev/federation-controller:test" not present locally
make: *** [Makefile:42: kind-clusters] Error 1
```

as the image tagged with `test` is not built.

This fix ensures that we build the image when `USE_LOCAL_IMAGE` is set to `true` so kind setup can succeed.