### PR TITLE
feat(make): introduces help target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,46 +3,47 @@ OUT := $(shell pwd)
 .PHONY: default
 default: build test
 
-export TAG ?= latest
 export HUB ?= quay.io/maistra-dev
+export TAG ?= latest
 export ISTIO_VERSION ?= 1.23.0
 export USE_LOCAL_IMAGE ?= true
 
+.PHONY: help
+help:
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-25s\033[0m\033[2m %s\033[0m\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Build
+
 .PHONY: build
-build:
+build: ## Builds the project
 	go get ./...
 	go build -C cmd/federation-controller -o "${OUT}/out/"
 
 .PHONY: test
-test: build
+test: build ## Runs tests
 	go test ./...
 
 CONTAINER_CLI ?= docker
 
 .PHONY: docker-build
-docker-build: build
+docker-build: build ## Builds container image
 	$(CONTAINER_CLI) build -t $(HUB)/federation-controller:$(TAG) -f build/Dockerfile .
 
 .PHONY: docker-push
-docker-push:
+docker-push: ## Pushes container image to the registry
 	$(CONTAINER_CLI) push $(HUB)/federation-controller:$(TAG)
 
 .PHONY: docker
-docker: docker-build docker-push
+docker: docker-build docker-push ## Combines build and push targets
 
-PROTO_DIR=api/proto/federation
-OUT_DIR=internal/api
-
-.PHONY: proto
-proto:
-	protoc --proto_path=$(PROTO_DIR) --go_out=$(OUT_DIR) --go-grpc_out=$(OUT_DIR) --golang-deepcopy_out=:$(OUT_DIR) $(PROTO_DIR)/**/*.proto
+##@ Development
 
 .PHONY: kind-clusters
-kind-clusters: build-test-image
+kind-clusters: build-test-image ## Provisions KinD clusters for local development or testing
 	bash test/scripts/kind_provisioner.sh $(ISTIO_VERSION)
 
 .PHONY: build-test-image
-build-test-image:
+build-test-image: ## Builds test image
 ifeq ($(USE_LOCAL_IMAGE), true)
 	$(MAKE) docker-build -e TAG=test
 endif
@@ -54,7 +55,7 @@ ifeq ($(USE_LOCAL_IMAGE),true)
 else
 	TEST_TAG := $(TAG)
 endif
-e2e: build-test-image kind-clusters
+e2e: build-test-image kind-clusters ## Runs end-to-end tests against KinD clusters
 	@$(foreach suite, $(TEST_SUITES), \
 		TAG=$(TEST_TAG) go test -tags=integ -run TestTraffic ./test/e2e/$(suite) \
 			--istio.test.hub=docker.io/istio\
@@ -63,15 +64,25 @@ e2e: build-test-image kind-clusters
 			--istio.test.kube.networkTopology=0:east-network,1:west-network\
 			--istio.test.onlyWorkloads=standard;)
 
+##@ Code Gen
+
+PROTO_DIR=api/proto/federation
+OUT_DIR=internal/api
+
+.PHONY: proto
+proto: ## Generates Go files from protobuf-based API files
+	protoc --proto_path=$(PROTO_DIR) --go_out=$(OUT_DIR) --go-grpc_out=$(OUT_DIR) --golang-deepcopy_out=:$(OUT_DIR) $(PROTO_DIR)/**/*.proto
+
+
 .PHONY: fix-imports
-fix-imports:
+fix-imports: ## Fixes imports
 	goimports -local "github.com/openshift-service-mesh/federation" -w .
 
 LICENSE_FILE := /tmp/license.txt
 GO_FILES := $(shell find . -name '*.go')
 
 .PHONY: add-license
-add-license:
+add-license: ## Adds license to all Golang files
 	@echo "// Copyright Red Hat, Inc." > $(LICENSE_FILE)
 	@echo "//" >> $(LICENSE_FILE)
 	@echo "// Licensed under the Apache License, Version 2.0 (the "License");" >> $(LICENSE_FILE)


### PR DESCRIPTION
As we have multiple targets defined having an easy overview of what is available without a need of skimming through `Makefile` can help newcomers.

For this purpose `make help` target has been introduced. Invoking it will print selected targets and their respective comments, giving a structured overview of available commands.

```sh
❯ make help

Usage:
  make <target>

Build
  build                      Builds the project
  test                       Runs tests
  docker-build               Builds container image
  docker-push                Pushes container image to the registry
  docker                     Combines build and push targets

Development
  kind-clusters              Provisions KinD clusters for local development or testing
  build-test-image           Builds test image

Code Gen
  proto                      Generates Go files from protobuf-based API files
  fix-imports                Fixes imports
  add-license                Adds license to all Golang files
```

Targets are grouped into sections marked by `##@ Section` and display comments added after their declarations with `##`.

> [!NOTE]
> We can also print available variables using similar pattern matching, but I am not sure how beneficial such information is if we only want a brief overview of what we can invoke.