### PR TITLE
docs: aligns istio release version in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,8 +25,8 @@ You can follow this [guide](spire/README.md) to see how these solutions work tog
 
 Download tools for certificate generation:
 ```shell
-wget https://raw.githubusercontent.com/istio/istio/release-1.21/tools/certs/common.mk -O common.mk
-wget https://raw.githubusercontent.com/istio/istio/release-1.21/tools/certs/Makefile.selfsigned.mk -O Makefile.selfsigned.mk
+wget https://raw.githubusercontent.com/istio/istio/release-1.22/tools/certs/common.mk -O common.mk
+wget https://raw.githubusercontent.com/istio/istio/release-1.22/tools/certs/Makefile.selfsigned.mk -O Makefile.selfsigned.mk
 ```
 
 #### Common root and trust domain


### PR DESCRIPTION
Instead of using `v1.21` for certificates and` v1.22` for the deployed bookinfo app we should have those unified.