### PR TITLE
feat(k8s): run all reconcilers in a single pass

### DIFF
--- a/internal/pkg/kube/reconciler_manager.go
+++ b/internal/pkg/kube/reconciler_manager.go
@@ -16,6 +16,7 @@ package kube
 
 import (
 	"context"
+	"errors"
 
 	istiolog "istio.io/istio/pkg/log"
 
@@ -42,12 +43,13 @@ func NewReconcilerManager(pushRequests <-chan xds.PushRequest, reconcilers ...Re
 }
 
 func (rm *ReconcilerManager) ReconcileAll(ctx context.Context) error {
+	reconcileErrs := make([]error, 0, len(rm.reconcilers))
+
 	for _, r := range rm.reconcilers {
-		if err := r.Reconcile(ctx); err != nil {
-			return err
-		}
+		reconcileErrs = append(reconcileErrs, r.Reconcile(ctx))
 	}
-	return nil
+
+	return errors.Join(reconcileErrs...)
 }
 
 func (rm *ReconcilerManager) Start(ctx context.Context) {


### PR DESCRIPTION
Runs all reconcilers in a single pass, allowing errors to be collected without early termination. It aligns with the "eventual consistency" nature of reconciling but also enables to either set up more in a single run or capture all problems and troubleshoot more efficiently.

By using `errors.Join` we can achieve "multi-error" semantic without using any additional library such as [hashicorp/go-multierror](https://github.com/hashicorp/go-multierror).