### PR TITLE
fix(git): ignores demo cert folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ out
 # demo output
 Makefile.selfsigned.mk
 common.mk
+east/
+west/
 east.kubeconfig
 west.kubeconfig
 test/testdata/out


### PR DESCRIPTION
When running snippets from `examples/README.md` folders with generated certs should be ignored to avoid being accidentally added under source control.

This change ensures both `east` and `west` folders are ignored.