### PR TITLE
helm: hardcode service name

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - '--exportedServiceSet={{ .Values.federation.exportedServiceSet | toJson }}'
         env:
         - name: CONTROLLER_SERVICE_FQDN
-          value: "{{ include "chart.name" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+          value: "federation-discovery-service.{{ .Release.Namespace }}.svc.cluster.local"
         ports:
         - name: grpc-fds
           containerPort: 15080

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "chart.name" . }}
+  name: federation-discovery-service
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}

--- a/internal/pkg/istio/config_factory.go
+++ b/internal/pkg/istio/config_factory.go
@@ -64,8 +64,8 @@ func (cf *ConfigFactory) GetDestinationRules() *v1alpha3.DestinationRule {
 			TrafficPolicy: &istionetv1alpha3.TrafficPolicy{
 				Tls: &istionetv1alpha3.ClientTLSSettings{
 					Mode: istionetv1alpha3.ClientTLSSettings_ISTIO_MUTUAL,
-					// SNI must come from the configured identity
-					Sni: fmt.Sprintf("federation-controller.%s.svc.cluster.local", cf.cfg.MeshPeers.Local.ControlPlane.Namespace),
+					// TODO: namespace should come from remote.identity.namespace
+					Sni: "federation-discovery-service.istio-system.svc.cluster.local",
 				},
 			},
 		},


### PR DESCRIPTION
Service name does not need to be configurable, and hardcoded name allows us to properly set SNI having only the identity, which includes service account, namespace and trust domain.