### PR TITLE
feat(make): customizable build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,11 @@ help:
 
 ##@ Build
 
+EXTRA_BUILD_ARGS?=
 .PHONY: build
 build: ## Builds the project
 	go get ./...
-	go build -C cmd/federation-controller -o "${OUT}/out/"
+	go build -C cmd/federation-controller -o "${OUT}/out/" $(EXTRA_BUILD_ARGS)
 
 .PHONY: test
 test: build ## Runs tests


### PR DESCRIPTION
Some tools may require adjustments to the build process, such as adding specific `ldflags`. These modifications are not always necessary or suitable for production binaries. Altering them directly in the default build target would not be ideal.

The `Makefile` now supports an `EXTRA_BUILD_ARGS` variable, enabling customization of the build process. For example, if a tool requires a dynamic linker, the build can be now modified as follows:

```sh
CGO_ENABLED=1 make build -e EXTRA_BUILD_ARGS='-ldflags "-linkmode external"'
```