### PR TITLE
feat(adsc): propagates ctx when creating gRPC stream

### DIFF
--- a/cmd/federation-controller/main.go
+++ b/cmd/federation-controller/main.go
@@ -225,9 +225,11 @@ func main() {
 
 	if fdsClient != nil {
 		go func() {
-			if err := fdsClient.Run(); err != nil {
+			if err := fdsClient.Run(ctx); err != nil {
 				log.Errorf("failed to start FDS client, will reconnect in %s: %v", reconnectDelay, err)
-				time.AfterFunc(reconnectDelay, fdsClient.Restart)
+				time.AfterFunc(reconnectDelay, func() {
+					fdsClient.Restart(ctx)
+				})
 			}
 		}()
 	}


### PR DESCRIPTION
To gracefully handle cancellation we can pass main context down to gRPC stream creation instead of creating background context.

This change introduces the ability to pass `context.Context` instance to relevant methods of ADS Client. It also removes the need to keep client instance as part of the struct, as this is only needed to create the stream and is never used afterward.

In addition, any error occurring when sending initial discovery requests is now logged.