### PR TITLE
feat(ci): ensures license headers are added

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,0 +1,25 @@
+name: linters
+on:
+  pull_request:
+    branches:
+    - master
+jobs:
+  check-license:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check licenses
+      run: | 
+        make add-license
+        clean=$(git status --porcelain --untracked-files=no | awk '{print $NF}')
+        if [[ -n "${clean}" ]]; then
+          files=$(printf "%s\n" "${clean}" | sed 's/^/- /')
+          {
+            echo "### :warning: Files Without License Found"
+            echo "Run `make add-license` and update your PR."
+            echo ""
+            echo "${files}"
+            echo ""
+          } >> $GITHUB_STEP_SUMMARY
+          exit 1
+        fi


### PR DESCRIPTION
`make add-license` target is not part of the default Makefile target, therefore it can be overlooked. But even if it were, there's no guarantee it will be run before a PR is opened or updated. 

The `linters/check-license` GitHub job verifies that every relevant file includes
the required license headers. Otherwise, job fails and lists files both in the [logs](https://github.com/bartoszmajsak/ossm-federation/actions/runs/12066829341/job/33648514031?pr=1)
of the job as well as in the [summary](https://github.com/bartoszmajsak/ossm-federation/actions/runs/12066829341?pr=1#summary-33648514031).