### PR TITLE
feat(chart): add "app" label to enable app recognition in Kiali

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -32,6 +32,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "chart.selectorLabels" -}}
+app: {{ include "chart.name" . }}
 app.kubernetes.io/name: {{ include "chart.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -22,7 +22,6 @@ spec:
       {{- end }}
       labels:
         {{- include "chart.labels" . | nindent 8 }}
-        app.kubernetes.io/name: federation-controller
         sidecar.istio.io/inject: "true"
     spec:
       serviceAccountName: {{ include "chart.name" . }}


### PR DESCRIPTION
Kiali uses `app` label to associate services and workloads as applications.

**Before:**
![kiali-before](https://github.com/user-attachments/assets/e9d77852-2239-4947-ad89-2b9288c15bc5)

**After:**
![kiali-after](https://github.com/user-attachments/assets/01df351e-54b9-4912-a124-5332a2e8fba6)
