### PR TITLE
feat(build): simplifies local image upload strategy

### DIFF
--- a/test/scripts/cluster.sh
+++ b/test/scripts/cluster.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+function create_kind_cluster {
+  cluster=$1
+  podSubnet=$2
+  svcSubnet=$3
+
+  echo "Creating cluster '$cluster' in podSubnet='$podSubnet' and svcSubnet='$svcSubnet'"
+
+  kind create cluster --name "$cluster" --config=<<EOF
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+networking:
+  podSubnet: "$podSubnet"
+  serviceSubnet: "$svcSubnet"
+EOF
+}
+
+function provision_kind_clusters {
+  echo "Creating KinD clusters"
+  kind_pids=()
+  create_kind_cluster east 10.10.0.0/16 10.255.10.0/24 &
+  kind_pids[0]=$!
+  create_kind_cluster west 10.30.0.0/16 10.255.30.0/24 &
+  kind_pids[1]=$!
+
+  for pid in ${kind_pids[*]}; do
+    wait $pid
+  done
+
+  kind get kubeconfig --name east > $ROOT/east.kubeconfig
+  kind get kubeconfig --name west > $ROOT/west.kubeconfig
+
+  echo "Installing MetalLB"
+  metallb_pids=()
+  install_metallb_retry east &
+  metallb_pids[0]=$!
+  install_metallb_retry west &
+  metallb_pids[1]=$!
+
+  for pid in ${metallb_pids[*]}; do
+    wait $pid
+  done
+}
+
+function install_metallb_retry {
+  retry install_metallb $1
+}
+
+function install_metallb() {
+  cluster=$1
+  kubectl --kubeconfig="$ROOT/$cluster.kubeconfig" apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml
+  kubectl --kubeconfig="$ROOT/$cluster.kubeconfig" wait -n metallb-system pod --timeout=120s -l app=metallb --for=condition=Ready
+
+  docker_kind_ipv4_subnet="$(docker inspect kind | jq '.[0].IPAM.Config' -r | jq -r '.[] | select(.Subnet | test("^[0-9]+\\.")) | .Subnet')"
+  cidr=$(python3 "$ROOT/scripts/find_smaller_subnets.py" --network "$docker_kind_ipv4_subnet" --region "$cluster")
+
+  echo '
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - '"$cidr"'
+  avoidBuggyIPs: true
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: default-l2
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - default-pool
+' | kubectl apply --kubeconfig="$ROOT/$cluster.kubeconfig" -f -
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  "$@"
+fi

--- a/test/scripts/kind_provisioner.sh
+++ b/test/scripts/kind_provisioner.sh
@@ -7,55 +7,35 @@ set -u
 # Print commands
 set -x
 
-WD=$(dirname "$0")
-WD=$(cd "$WD"; pwd)
-ROOT=$(dirname "$WD")
-
-istio_version=$1
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 source "$ROOT/scripts/lib.sh"
+source "$ROOT/scripts/cluster.sh"
 
-found_clusters=0
-for name in "east" "west"; do
-  if kind get clusters | grep -q "$name"; then
-    found_clusters=$((found_clusters+1))
-  else
-    echo "Not found cluster $name"
-  fi
-done
+clusters=("east" "west")
+all_clusters=$(kind get clusters 2>&1)
+matching_clusters=$(echo "$all_clusters" | grep -c -E "$(printf '%s|' "${clusters[@]}" | sed 's/|$//')" || true)
 
-if [ "$found_clusters" -eq "2" ]; then
-  echo "All clusters were found - skipping clusters provisioning."
-  upload_test_image
-  exit 0
-elif [ "$found_clusters" -ne "0" ]; then
-  echo "Did not find all clusters, but some exist - cleanup environment and run script again."
+if [ "$matching_clusters" -eq 0 ]; then
+  echo "No required clusters found. Provisioning..."
+  provision_kind_clusters
+elif [ "$matching_clusters" -ne "${#clusters[@]}" ]; then
+  echo "Partial cluster setup detected. Please clean up the environment and retry."
+  echo "Suggested command: kind delete clusters ${clusters[*]}"
   exit 1
 fi
 
-echo "Creating KinD clusters"
-kind_pids=()
-create_kind_cluster east 10.10.0.0/16 10.255.10.0/24 &
-kind_pids[0]=$!
-create_kind_cluster west 10.30.0.0/16 10.255.30.0/24 &
-kind_pids[1]=$!
+USE_LOCAL_IMAGE=${USE_LOCAL_IMAGE:-false}
+if [ "$USE_LOCAL_IMAGE" == "true" ]; then
+  pids=()
+  for cluster in "${clusters[@]}"; do
+    upload_image "${cluster}" &
+    pids+=($!)
+  done
 
-for pid in ${kind_pids[*]}; do
-  wait $pid
-done
+  for pid in "${pids[@]}"; do
+    wait "$pid" || echo "Process $pid failed"
+  done
+fi
 
-kind get kubeconfig --name east > $ROOT/east.kubeconfig
-kind get kubeconfig --name west > $ROOT/west.kubeconfig
-
-echo "Installing MetalLB"
-metallb_pids=()
-install_metallb_retry east &
-metallb_pids[0]=$!
-install_metallb_retry west &
-metallb_pids[1]=$!
-
-for pid in ${metallb_pids[*]}; do
-  wait $pid
-done
-
-upload_test_image
+echo "Provisioning finished"

--- a/test/scripts/lib.sh
+++ b/test/scripts/lib.sh
@@ -1,68 +1,13 @@
 #!/bin/bash
 
-WD=$(dirname "$0")
-WD=$(cd "$WD"; pwd)
-ROOT=$(dirname "$WD")
+function upload_image {
+  local cluster=$1
+  local hub=${2:-${HUB:-quay.io/maistra-dev}}
+  local tag=${3:-${TAG:-latest}}
 
-function create_kind_cluster {
-  name=$1
-  podSubnet=$2
-  svcSubnet=$3
-
-  echo "Creating cluster '$name' in podSubnet='$podSubnet' and svcSubnet='$svcSubnet'"
-
-  kind create cluster --name "$name" --config=<<EOF
-apiVersion: kind.x-k8s.io/v1alpha4
-kind: Cluster
-networking:
-  podSubnet: "$podSubnet"
-  serviceSubnet: "$svcSubnet"
-EOF
-}
-
-function install_metallb_retry {
-  retry install_metallb $1
-}
-
-function install_metallb() {
-  cluster=$1
-  kubectl --kubeconfig="$ROOT/$cluster.kubeconfig" apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml
-  kubectl --kubeconfig="$ROOT/$cluster.kubeconfig" wait -n metallb-system pod --timeout=120s -l app=metallb --for=condition=Ready
-
-  docker_kind_ipv4_subnet="$(docker inspect kind | jq '.[0].IPAM.Config' -r | jq -r '.[] | select(.Subnet | test("^[0-9]+\\.")) | .Subnet')"
-  cidr=$(python3 "$ROOT/scripts/find_smaller_subnets.py" --network "$docker_kind_ipv4_subnet" --region "$cluster")
-
-  echo '
-apiVersion: metallb.io/v1beta1
-kind: IPAddressPool
-metadata:
-  name: default-pool
-  namespace: metallb-system
-spec:
-  addresses:
-  - '"$cidr"'
-  avoidBuggyIPs: true
----
-apiVersion: metallb.io/v1beta1
-kind: L2Advertisement
-metadata:
-  name: default-l2
-  namespace: metallb-system
-spec:
-  ipAddressPools:
-  - default-pool
-' | kubectl apply --kubeconfig="$ROOT/$cluster.kubeconfig" -f -
-}
-
-function upload_test_image {
-  if [ "$USE_LOCAL_IMAGE" == "true" ]; then
-    echo "Uploading images"
-    for cluster_name in "east" "west"; do
-      kind load docker-image --nodes "${cluster_name}-control-plane" --name "$cluster_name" quay.io/maistra-dev/federation-controller:test
-    done
-  else
-    echo "Skipped uploading test image"
-  fi
+  kind load docker-image --nodes "${cluster}-control-plane" \
+        --name "$cluster" \
+        ${hub}/federation-controller:${tag}
 }
 
 function retry {
@@ -81,3 +26,7 @@ function retry {
     fi
   done
 }
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  "$@"
+fi


### PR DESCRIPTION
When we want to use a locally built image for testing, instead of relying on the arbitrary `test` tag, we can follow a convention of appending `-local` suffix to any tag configured through the `TAG` variable. Such an appended tag is only used when provisioning KinD clusters and running e2e tests.

This PR simplifies the process of uploading the image to KinD cluster by moving the decision of performing it outside of the function itself. The function now accepts `cluster`, `hub` and `tag` as *ordered* parameters. The last two are defaulted when not passed or passed as empty (`""`).

The scripts have been cleaned up and some functions moved to their own files.

Any function in `lib.sh` and `cluster.sh` can now be invoked directly from the shell. So you can e.g. update image in the running cluster.

<details>
<summary>Using upload_image from shell</summary>

```shell
❯ ./test/scripts/lib.sh upload_image west
Image with ID: sha256:ed8b3ed32e2d14ebafef7f63fdabfb648cefcc5a986df8f24f76f44361cf6a0c already present on the node west-control-plane but is missing the tag quay.io/maistra-dev/federation-controller:latest. re-tagging...

❯ ./test/scripts/lib.sh upload_image west quay.io/bartoszmajsak test-tag
Image: "quay.io/bartoszmajsak/federation-controller:test-tag" with ID "sha256:83595794b2d74dabbfc975a07bf7f6ced0d9e3d9e3aea50a9f1e6704c7fa2478" not yet present on node "west-control-plane", loading...

❯ ./test/scripts/lib.sh upload_image west "" test-tag
Image with ID: sha256:83595794b2d74dabbfc975a07bf7f6ced0d9e3d9e3aea50a9f1e6704c7fa2478 already present on the node west-control-plane but is missing the tag quay.io/maistra-dev/federation-controller:test-tag. re-tagging...

```

> [!NOTE]
> The function relies on `HUB` and `TAG` env variables values if parameters
> are not passed explicitly. If these are not specified, default values
are used. But if you want to just override `TAG`, pass "" for the  second parameter
> (`HUB`) like in the last example above.

</details>



