### PR TITLE
chore(kind): simplifies cluster setup

### DIFF
--- a/test/scripts/cluster.sh
+++ b/test/scripts/cluster.sh
@@ -2,60 +2,29 @@
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
-function create_kind_cluster {
-  cluster=$1
-  podSubnet=$2
-  svcSubnet=$3
-
-  echo "Creating cluster '$cluster' in podSubnet='$podSubnet' and svcSubnet='$svcSubnet'"
+provision_kind_cluster() {
+  local cluster=$1
 
   kind create cluster --name "$cluster" --config=<<EOF
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
-networking:
-  podSubnet: "$podSubnet"
-  serviceSubnet: "$svcSubnet"
 EOF
+
+  kind get kubeconfig --name "${cluster}" > $ROOT/${cluster}.kubeconfig
+
+  retry install_metallb $cluster
 }
 
-function provision_kind_clusters {
-  echo "Creating KinD clusters"
-  kind_pids=()
-  create_kind_cluster east 10.10.0.0/16 10.255.10.0/24 &
-  kind_pids[0]=$!
-  create_kind_cluster west 10.30.0.0/16 10.255.30.0/24 &
-  kind_pids[1]=$!
+install_metallb() {
+  local cluster=$1
 
-  for pid in ${kind_pids[*]}; do
-    wait $pid
-  done
+  echo "Installing MetalLB for $cluster"
 
-  kind get kubeconfig --name east > $ROOT/east.kubeconfig
-  kind get kubeconfig --name west > $ROOT/west.kubeconfig
-
-  echo "Installing MetalLB"
-  metallb_pids=()
-  install_metallb_retry east &
-  metallb_pids[0]=$!
-  install_metallb_retry west &
-  metallb_pids[1]=$!
-
-  for pid in ${metallb_pids[*]}; do
-    wait $pid
-  done
-}
-
-function install_metallb_retry {
-  retry install_metallb $1
-}
-
-function install_metallb() {
-  cluster=$1
   kubectl --kubeconfig="$ROOT/$cluster.kubeconfig" apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml
   kubectl --kubeconfig="$ROOT/$cluster.kubeconfig" wait -n metallb-system pod --timeout=120s -l app=metallb --for=condition=Ready
 
-  docker_kind_ipv4_subnet="$(docker inspect kind | jq '.[0].IPAM.Config' -r | jq -r '.[] | select(.Subnet | test("^[0-9]+\\.")) | .Subnet')"
-  cidr=$(python3 "$ROOT/scripts/find_smaller_subnets.py" --network "$docker_kind_ipv4_subnet" --region "$cluster")
+  local docker_kind_ipv4_subnet="$(docker inspect kind | jq '.[0].IPAM.Config' -r | jq -r '.[] | select(.Subnet | test("^[0-9]+\\.")) | .Subnet')"
+  local cidr=$(python3 "$ROOT/scripts/find_smaller_subnets.py" --network "$docker_kind_ipv4_subnet" --region "$cluster")
 
   echo '
 apiVersion: metallb.io/v1beta1
@@ -77,6 +46,16 @@ spec:
   ipAddressPools:
   - default-pool
 ' | kubectl apply --kubeconfig="$ROOT/$cluster.kubeconfig" -f -
+}
+
+upload_image() {
+  local cluster=$1
+  local hub=${2:-${HUB:-quay.io/maistra-dev}}
+  local tag=${3:-${TAG:-latest}}
+
+  kind load docker-image --nodes "${cluster}-control-plane" \
+        --name "$cluster" \
+        ${hub}/federation-controller:${tag}
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/test/scripts/cluster.sh
+++ b/test/scripts/cluster.sh
@@ -5,11 +5,7 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 provision_kind_cluster() {
   local cluster=$1
 
-  kind create cluster --name "$cluster" --config=<<EOF
-apiVersion: kind.x-k8s.io/v1alpha4
-kind: Cluster
-EOF
-
+  kind create cluster --name "$cluster"
   kind get kubeconfig --name "${cluster}" > $ROOT/${cluster}.kubeconfig
 
   retry install_metallb $cluster

--- a/test/scripts/kind_provisioner.sh
+++ b/test/scripts/kind_provisioner.sh
@@ -9,8 +9,8 @@ set -x
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
-source "$ROOT/scripts/lib.sh"
 source "$ROOT/scripts/cluster.sh"
+source "$ROOT/scripts/lib.sh"
 
 clusters=("east" "west")
 all_clusters=$(kind get clusters 2>&1)
@@ -18,12 +18,23 @@ matching_clusters=$(echo "$all_clusters" | grep -c -E "$(printf '%s|' "${cluster
 
 if [ "$matching_clusters" -eq 0 ]; then
   echo "No required clusters found. Provisioning..."
-  provision_kind_clusters
+
+  pids=()
+  for cluster in "${clusters[@]}"; do
+    provision_kind_cluster "${cluster}" &
+    pids+=($!)
+  done
+
+  for pid in "${pids[@]}"; do
+    wait "$pid" || echo "Process $pid failed"
+  done
+
 elif [ "$matching_clusters" -ne "${#clusters[@]}" ]; then
   echo "Partial cluster setup detected. Please clean up the environment and retry."
   echo "Suggested command: kind delete clusters ${clusters[*]}"
   exit 1
 fi
+
 
 USE_LOCAL_IMAGE=${USE_LOCAL_IMAGE:-false}
 if [ "$USE_LOCAL_IMAGE" == "true" ]; then

--- a/test/scripts/kind_provisioner.sh
+++ b/test/scripts/kind_provisioner.sh
@@ -26,7 +26,7 @@ if [ "$matching_clusters" -eq 0 ]; then
   done
 
   for pid in "${pids[@]}"; do
-    wait "$pid" || echo "Process $pid failed"
+    wait "$pid" || { echo "Failed provisioning kind cluster (pid: $pid)"; exit 1; };
   done
 
 elif [ "$matching_clusters" -ne "${#clusters[@]}" ]; then
@@ -34,7 +34,6 @@ elif [ "$matching_clusters" -ne "${#clusters[@]}" ]; then
   echo "Suggested command: kind delete clusters ${clusters[*]}"
   exit 1
 fi
-
 
 USE_LOCAL_IMAGE=${USE_LOCAL_IMAGE:-false}
 if [ "$USE_LOCAL_IMAGE" == "true" ]; then

--- a/test/scripts/lib.sh
+++ b/test/scripts/lib.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 
-function upload_image {
-  local cluster=$1
-  local hub=${2:-${HUB:-quay.io/maistra-dev}}
-  local tag=${3:-${TAG:-latest}}
-
-  kind load docker-image --nodes "${cluster}-control-plane" \
-        --name "$cluster" \
-        ${hub}/federation-controller:${tag}
-}
-
-function retry {
+retry() {
   local n=1
   local max=5
   local delay=5


### PR DESCRIPTION
This change expands the cluster provisioning logic to support more than two clusters.

Functions for creating clusters and MetalLB are simplified, allowing parameterized invocation from the main script.

Pod and service subnet parameters are removed as they are no longer required. See [this comment](https://github.com/openshift-service-mesh/federation/pull/92#discussion_r1862738653) for details.

Functions are updated to be POSIX-compliant, improving portability across different shells.

Additionally, the `upload_image` function is moved to `cluster.sh` where it belongs.