### PR TITLE
fix(make): ensures binary is built against up-to-date code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help:
 
 EXTRA_BUILD_ARGS?=
 .PHONY: build
-build: ## Builds the project
+build: proto add-license ## Builds the project
 	go get $(PROJECT_DIR)/...
 	go build -C $(PROJECT_DIR)/cmd/federation-controller -o $(PROJECT_DIR)/$(OUT_DIR)/federation-controller $(EXTRA_BUILD_ARGS)
 


### PR DESCRIPTION
In order to ensure that up-to-date codebase is used to build the binary, we should automate  Golang stubs generation based on protobuf API changes.

This step was missing in the build process, requiring developer to call it explicitly.

With this fix, `proto` stubs are generated automatically. Additionally license headers are added, otherwise generation makes them disappear. As a bonus we ensure all relevant source files have now license headers added for each invocation of `build` target.