### PR TITLE
fix(make): ensures tools installation for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,10 @@ kind-clusters: ## Provisions KinD clusters for local development or testing
 
 .PHONY: e2e
 TEST_SUITES ?= k8s spire
-e2e: kind-clusters ## Runs end-to-end tests against KinD clusters
+e2e: tools kind-clusters ## Runs end-to-end tests against KinD clusters
 	@local_tag=$(call local_tag); \
 	$(foreach suite, $(TEST_SUITES), \
+		PATH=$(LOCALBIN):$$PATH \
 		TAG=$$local_tag \
 		go test -tags=integ -run TestTraffic $(PROJECT_DIR)/test/e2e/$(suite) \
 			--istio.test.hub=docker.io/istio\


### PR DESCRIPTION
E2E tests rely on external tools such as `helm`. With the introduction of `tools` target we are able to provide those binaries with the version we need, but running `make e2e` on freshly cloned project can fail, as ensuring that right tools are on the `PATH` is not part of it.

This change adds `tools` as dependent target for `e2e` and makes required binaries part of used `PATH` so test code can invoked needed commands.