### PR TITLE
fix(ci): uses python3 instead of unzip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,11 @@ $(HELM): $(LOCALBIN)
 
 $(PROTOC): $(LOCALBIN)
 	@curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip -o $(LOCALBIN)/protoc.zip
-	@unzip -q -j -o $(LOCALBIN)/protoc.zip "bin/protoc" -d $(LOCALBIN)
+	@python3 -c "import zipfile; z=zipfile.ZipFile('$(LOCALBIN)/protoc.zip'); z.extract('bin/protoc', '$(LOCALBIN)')"
+	@mv $(LOCALBIN)/bin/protoc $(LOCALBIN)
+	@rm -rf $(LOCALBIN)/bin
 	@rm -f $(LOCALBIN)/protoc.zip
+	@chmod +x $(PROTOC)
 
 $(PROTOC_GEN_GO): $(LOCALBIN)
 	@GOBIN=$(LOCALBIN) go install google.golang.org/protobuf/cmd/protoc-gen-go@latest


### PR DESCRIPTION
`ci-operator` image used by prow builder does not come with `unzip` tool causing `proto` target to fail.

This change reworks extracting `protoc` binary using python3 snippet instead, which is available as part of prow toolchain. We also rely on it to calculate subnets for `kind` clusters provisioning.

This will fix #95 and #96.