### PR TITLE
feat(fds): groups federated services by remote peers

### DIFF
--- a/api/proto/federation/v1alpha1/exported_service.proto
+++ b/api/proto/federation/v1alpha1/exported_service.proto
@@ -4,9 +4,11 @@ package v1alpha1;
 
 option go_package = "federation/v1alpha1";
 
-// ExportedService represents a service with a name and namespace.
+// ExportedService represents a service available across federated meshes with a name and namespace.
 message ExportedService {
+  // Name of the exported service
   string name = 1;
+  // Namespace where exported service is defined
   string namespace = 2;
   repeated ServicePort ports = 3;
   map<string, string> labels = 4;

--- a/cmd/federation-controller/main.go
+++ b/cmd/federation-controller/main.go
@@ -142,15 +142,20 @@ func main() {
 	}()
 
 	var fdsClient *adsc.ADSC
-	if len(cfg.MeshPeers.Remote.Addresses) > 0 {
+
+	remote := cfg.MeshPeers.Remote
+
+	if len(remote.Addresses) > 0 {
+		remoteName := remote.Name
 		var discoveryAddr string
-		if cfg.MeshPeers.Remote.IngressType == config.OpenShiftRouter {
-			discoveryAddr = cfg.MeshPeers.Remote.Addresses[0]
+		if remote.IngressType == config.OpenShiftRouter {
+			discoveryAddr = remote.Addresses[0]
 		} else {
-			discoveryAddr = fmt.Sprintf("federation-discovery-service-%s.%s.svc.cluster.local:15080", cfg.MeshPeers.Remote.Name, cfg.MeshPeers.Local.ControlPlane.Namespace)
+			discoveryAddr = fmt.Sprintf("federation-discovery-service-%s.%s.svc.cluster.local:15080", remoteName, cfg.MeshPeers.Local.ControlPlane.Namespace)
 		}
 		var err error
 		fdsClient, err = adsc.New(&adsc.ADSCConfig{
+			PeerName:      remoteName,
 			DiscoveryAddr: discoveryAddr,
 			InitialDiscoveryRequests: []*discovery.DiscoveryRequest{{
 				TypeUrl: xds.ExportedServiceTypeUrl,
@@ -161,7 +166,7 @@ func main() {
 			ReconnectDelay: reconnectDelay,
 		})
 		if err != nil {
-			log.Fatalf("failed to create FDS client: %v", err)
+			log.Fatalf("failed to create FDS client to remote %s: %v", remoteName, err)
 		}
 	}
 
@@ -182,14 +187,14 @@ func main() {
 		reconcilers = append(reconcilers, kube.NewRouteReconciler(routeClient, openshift.NewConfigFactory(*cfg, serviceLister)))
 
 		go func() {
-			log.Debugf("Resolving %s", cfg.MeshPeers.Remote.Addresses[0])
-			lastIPs := networking.Resolve(cfg.MeshPeers.Remote.Addresses[0])
+			log.Debugf("Resolving %s", remote.Addresses[0])
+			lastIPs := networking.Resolve(remote.Addresses[0])
 			for {
-				log.Debugf("Resolving %s", cfg.MeshPeers.Remote.Addresses[0])
-				ips := networking.Resolve(cfg.MeshPeers.Remote.Addresses[0])
+				log.Debugf("Resolving %s", remote.Addresses[0])
+				ips := networking.Resolve(remote.Addresses[0])
 				sort.Strings(ips)
 				if !slices.Equal(lastIPs, ips) {
-					log.Infof("IP addresses of %s have changed", cfg.MeshPeers.Remote.Addresses[0])
+					log.Infof("IP addresses of %s have changed", remote.Addresses[0])
 					lastIPs = ips
 					meshConfigPushRequests <- xds.PushRequest{TypeUrl: xds.ServiceEntryTypeUrl}
 					meshConfigPushRequests <- xds.PushRequest{TypeUrl: xds.WorkloadEntryTypeUrl}

--- a/internal/api/federation/v1alpha1/exported_service.pb.go
+++ b/internal/api/federation/v1alpha1/exported_service.pb.go
@@ -21,10 +21,11 @@
 package v1alpha1
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -34,13 +35,15 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// ExportedService represents a service with a name and namespace.
+// ExportedService represents a service available across federated meshes with a name and namespace.
 type ExportedService struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Name      string            `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Name of the exported service
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Namespace where exported service is defined
 	Namespace string            `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	Ports     []*ServicePort    `protobuf:"bytes,3,rep,name=ports,proto3" json:"ports,omitempty"`
 	Labels    map[string]string `protobuf:"bytes,4,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`

--- a/internal/pkg/fds/exported_service_generator_test.go
+++ b/internal/pkg/fds/exported_service_generator_test.go
@@ -32,6 +32,11 @@ import (
 
 var (
 	federationConfig = config.Federation{
+		MeshPeers: config.MeshPeers{
+			Local: config.Local{
+				Name: "cluster-local",
+			},
+		},
 		ExportedServiceSet: config.ExportedServiceSet{
 			Rules: []config.Rules{{
 				Type: "LabelSelector",

--- a/internal/pkg/xds/adsc/adsc.go
+++ b/internal/pkg/xds/adsc/adsc.go
@@ -37,6 +37,7 @@ const (
 var log = istiolog.RegisterScope("adsc", "Aggregated Discovery Service Client")
 
 type ADSCConfig struct {
+	PeerName                 string
 	DiscoveryAddr            string
 	InitialDiscoveryRequests []*discovery.DiscoveryRequest
 	Handlers                 map[string]ResponseHandler
@@ -132,7 +133,7 @@ func (a *ADSC) handleRecv(ctx context.Context) {
 		}
 		log.Infof("received response for %s: %v", msg.TypeUrl, msg.Resources)
 		if handler, found := a.cfg.Handlers[msg.TypeUrl]; found {
-			if err := handler.Handle(msg.Resources); err != nil {
+			if err := handler.Handle(a.cfg.PeerName, msg.Resources); err != nil {
 				log.Infof("error handling resource %s: %v", msg.TypeUrl, err)
 			}
 		} else {

--- a/internal/pkg/xds/adsc/response_handler.go
+++ b/internal/pkg/xds/adsc/response_handler.go
@@ -18,5 +18,5 @@ import "google.golang.org/protobuf/types/known/anypb"
 
 // ResponseHandler handles response received from an XDS server.
 type ResponseHandler interface {
-	Handle(resources []*anypb.Any) error
+	Handle(source string, resources []*anypb.Any) error
 }

--- a/internal/pkg/xds/adss/adss_handler.go
+++ b/internal/pkg/xds/adss/adss_handler.go
@@ -121,7 +121,7 @@ func (adss *adsServer) generateResources(typeUrl string) ([]*anypb.Any, error) {
 		log.Infof("Generating config snapshot for type %s", typeUrl)
 		if resources, err := handler.GenerateResponse(); err != nil {
 			log.Errorf("error generating resources of type %s: %v", typeUrl, err)
-			return []*anypb.Any{}, err
+			return []*anypb.Any{}, fmt.Errorf("error generating resources of type %s: %w", typeUrl, err)
 		} else {
 			return resources, nil
 		}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR doesn't include the code required to handle multiple peers yet.
> This is a refactoring of existing data structures first and preserves the current logic.

This PR refactors existing code to facilitate more than one peer by keeping
each federated service (imported from remote) grouped by remote's name.

Initial assumption to rely on `XFCC` header was unsuccessful, as received gRPC 
stream did not have expected headers (or I couldn't get them by using gRPC API
for fetching Metadata in case of Aggregated Discover Service).

Instead of relying on the peer identity passed as part of discovery
response we can group federated services by remote names (aliases)
defined as initial config. 

With this approach we can ensure uniqueness of peer names locally
(which will be solved when they become Custom Resources anyway)
and avoid naming collisions which can lead to wrongly assigned 
federated services.

Fixes #62
Closes #101
