### PR TITLE
feat(config): controller's namespace autodiscovery

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -33,9 +33,6 @@ spec:
         args:
         - '--meshPeers={{ .Values.federation.meshPeers | toJson }}'
         - '--exportedServiceSet={{ .Values.federation.exportedServiceSet | toJson }}'
-        env:
-        - name: NAMESPACE
-          value: {{ .Release.Namespace }}
         ports:
         - name: grpc-fds
           containerPort: 15080

--- a/internal/pkg/config/cluster.go
+++ b/internal/pkg/config/cluster.go
@@ -1,0 +1,36 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+func Namespace() string {
+	// First, check POD_NAMESPACE environment variable if Downward API is used
+	if ns, defined := os.LookupEnv("POD_NAMESPACE"); defined {
+		return ns
+	}
+
+	// Next, if using service account token, rely on mounted secret
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(data)); ns != "" {
+			return ns
+		}
+	}
+
+	return "istio-system"
+}


### PR DESCRIPTION
We do not need special environment variable to determine where our controller runs. To achieve this we could either use Downward API environment variable called `POD_NAMESPACE` or rely on the fact that we are using Service Account which automatically propagates namespace as mounted secret.

This PR introduces `config.Namespace` function which resolves namespace in the exact order mentioned above or falls back to `istio-system`.

Bonus: it also re-uses Istio's underyling k8s client for the informers instead of creating new instance.