### PR TITLE
feat(build): adds fix-imports to build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help:
 
 EXTRA_BUILD_ARGS?=
 .PHONY: build
-build: proto add-license ## Builds the project
+build: proto add-license fix-imports ## Builds the project
 	go get $(PROJECT_DIR)/...
 	go build -C $(PROJECT_DIR)/cmd/federation-controller -o $(PROJECT_DIR)/$(OUT_DIR)/federation-controller $(EXTRA_BUILD_ARGS)
 


### PR DESCRIPTION
To avoid misconfigured go imports we can invoke `fix-imports` as part of the `build` target.

This can limit cases when PRs come with wrongly formatted code.