### PR TITLE
fix(cmd): wait for root context to finish

### DIFF
--- a/cmd/federation-controller/main.go
+++ b/cmd/federation-controller/main.go
@@ -213,5 +213,5 @@ func main() {
 		}()
 	}
 
-	select {}
+	<-ctx.Done()
 }


### PR DESCRIPTION
We shouldn't wait indefinitely by using `select {}`, but until the main context is `Done`. 

It ensures we exit the process cleanly in case of termination or cancel. This way kubelet can restart the controller instead of keeping it running in a broken state (i.e. reconciller will stop working when context is `Done`).