### PR TITLE
fix(e2e): aligns echo app version with Istio

### DIFF
--- a/test/e2e/common/setup.go
+++ b/test/e2e/common/setup.go
@@ -58,7 +58,7 @@ var (
 	testHub = env.GetString("HUB", "quay.io/maistra-dev")
 	testTag = env.GetString("TAG", "latest")
 
-	istioVersion = env.GetString("ISTIO_VERSION", "1.22.1")
+	istioVersion = env.GetString("ISTIO_VERSION", "1.23.0")
 )
 
 const (
@@ -284,6 +284,7 @@ func DeployApps(apps *echo.Instances, targetClusterName string, ns namespace.Get
 			appConfig := echo.Config{
 				Service:   name,
 				Namespace: ns.Get(),
+				Version:   istioVersion,
 				Ports: echo.Ports{
 					ports.HTTP,
 					ports.GRPC,


### PR DESCRIPTION
If we do not set `--istio.test.tag` when running tests (which can happen from the IDE), Echo App uses `latest` tag, as we do not propogate default `istioVersion` we have defined in the test setup.

As a consequence tests are failing, because `app:latest` is 5y old and does not support flags defined for the container in Istio Test Framework template.

Additionally `istioVersion` variable has been aligned with what's defined as default in the `Makefile`.