### PR TITLE
fix(config): fails on unknown fields

### DIFF
--- a/internal/pkg/config/parse.go
+++ b/internal/pkg/config/parse.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"encoding/json"
 )
@@ -47,9 +48,13 @@ func ParseArgs(meshPeers, exportedServiceSet, importedServiceSet string) (*Feder
 	}, nil
 }
 
-func unmarshalJSON(input string, out interface{}) error {
-	if err := json.Unmarshal([]byte(input), out); err != nil {
+func unmarshalJSON(input string, out any) error {
+	dec := json.NewDecoder(strings.NewReader(input))
+	dec.DisallowUnknownFields()
+
+	if err := dec.Decode(&out); err != nil {
 		return fmt.Errorf("failed to unmarshal JSON: %w", err)
 	}
+
 	return nil
 }


### PR DESCRIPTION
Previously, the configuration parsing used a default JSON decoder that ignored any unknown fields. This could lead to runtime errors when the configuration contained typos or unrecognized properties.

By switching to a decoder that rejects unknown fields, we ensure that configuration errors are caught early.