### PR TITLE
fix(e2e): creates more subnets for kind clusters

### DIFF
--- a/test/scripts/find_subnets.py
+++ b/test/scripts/find_subnets.py
@@ -6,13 +6,13 @@ import sys
 def find_subnets(network, required_subnets):
     try:
         network = ipaddress.ip_network(network, strict=False)
-        bits_needed = math.ceil(math.log2(required_subnets))
+        bits_needed = math.ceil(math.log2(required_subnets+2))
 
         new_mask = network.prefixlen + bits_needed
         if new_mask > network.max_prefixlen:
             raise ValueError("Cannot create that many subnets with the given network.")
 
-        return list(network.subnets(new_prefix=new_mask))
+        return list(network.subnets(new_prefix=new_mask))[1:]
     except ValueError as e:
         print(f"Error: {e}")
         sys.exit(1)


### PR DESCRIPTION
In the reworked version of subnet calculation script (#99) we removed the additional subnet creation.

This proved to be necessary, as there's an issue when re-using first subnet, leading to flaky setup, especially when using `istioctl`.

The overlap manifests itself with timeng out when calling `kube-apiserver`:

<details>
<summary>$ istioctl connection errors</summary>

```sh
2024-12-16T11:25:04.161607Z	info	tf	istioctl error: Error: check minimum supported Kubernetes version: error getting Kubernetes version: Get "https://127.0.0.1:42735/version?timeout=5s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
2024-12-16T11:25:04.161635Z	error	tf	Test setup error: failed to deploy istio: stdout: ; err: check minimum supported Kubernetes version: error getting Kubernetes version: Get "https://127.0.0.1:42735/version?timeout=5s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
2024-12-16T11:25:04.161637Z	info	tf	=== FAILED: Setup: '_home_bartek_code_redhat_ossm_federation_test_e2e_remote_dns_name' (failed to deploy istio: stdout: ; err: check minimum supported Kubernetes version: error getting Kubernetes version: Get "https://127.0.0.1:42735/version?timeout=5s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)) ===
2024-12-16T11:25:04.161639Z	error	tf	Exiting due to setup failure: failed to deploy istio: stdout: ; err: check minimum supported Kubernetes version: error getting Kubernetes version: Get "https://127.0.0.1:42735/version?timeout=5s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
2024-12-16T11:25:37.492547Z	error	tf	failed to delete control plane namespace (cluster=west): Delete "https://127.0.0.1:42735/api/v1/namespaces/istio-system": http2: client connection lost
```

</details>

This PR brings back the original logic which seems to mitigate the issue.

"Scientific method" proving that the solution works was to run `make e2e` multiple times against two versions of the script and observe the occurrence of the error above. For n=16 this version had 0 failures, whereas the buggy rework seems to hit 12/16 failures.

> [!IMPORTANT]
> Another issue that can affect clusters' responsives is pod erroring with "too many open files" errors. 
>
> It is a known issue that can be now more frequent as we have 3 clusters set up as part of the end-to-end setup. See https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files