### PR TITLE
fix(make): prevents redundant binary downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,18 +82,17 @@ e2e: kind-clusters ## Runs end-to-end tests against KinD clusters
 
 ##@ Tooling
 
-$(LOCALBIN):
-	@mkdir -p $(LOCALBIN)
+$(shell mkdir -p $(LOCALBIN))
 
-$(GOIMPORTS): $(LOCALBIN)
+$(GOIMPORTS):
 	@GOBIN=$(LOCALBIN) go install -mod=readonly golang.org/x/tools/cmd/goimports@latest
 
-$(HELM): $(LOCALBIN)
+$(HELM):
 	@curl -sSL https://get.helm.sh/helm-v3.14.2-linux-amd64.tar.gz -o $(LOCALBIN)/helm.tar.gz
 	@tar -xzf $(LOCALBIN)/helm.tar.gz -C $(LOCALBIN) --strip-components=1 linux-amd64/helm
 	@rm -f $(LOCALBIN)/helm.tar.gz
 
-$(PROTOC): $(LOCALBIN)
+$(PROTOC):
 	@curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip -o $(LOCALBIN)/protoc.zip
 	@python3 -c "import zipfile; z=zipfile.ZipFile('$(LOCALBIN)/protoc.zip'); z.extract('bin/protoc', '$(LOCALBIN)')"
 	@mv $(LOCALBIN)/bin/protoc $(LOCALBIN)
@@ -101,17 +100,17 @@ $(PROTOC): $(LOCALBIN)
 	@rm -f $(LOCALBIN)/protoc.zip
 	@chmod +x $(PROTOC)
 
-$(PROTOC_GEN_GO): $(LOCALBIN)
-	@GOBIN=$(LOCALBIN) go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.0
+$(PROTOC_GEN_GO):
+	@GOBIN=$(LOCALBIN) go install -mod=readonly google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.0
 
-$(PROTOC_GEN_GRPC): $(LOCALBIN)
-	@GOBIN=$(LOCALBIN) go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
+$(PROTOC_GEN_GRPC):
+	@GOBIN=$(LOCALBIN) go install -mod=readonly google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
 
-$(PROTOC_GEN_DEEPCOPY): $(LOCALBIN)
-	@GOBIN=$(LOCALBIN) go install istio.io/tools/cmd/protoc-gen-golang-deepcopy@latest
+$(PROTOC_GEN_DEEPCOPY):
+	@GOBIN=$(LOCALBIN) go install -mod=readonly istio.io/tools/cmd/protoc-gen-golang-deepcopy@latest
 
-$(KIND): $(LOCALBIN)
-	@GOBIN=$(LOCALBIN) go install sigs.k8s.io/kind@v0.26.0
+$(KIND):
+	@GOBIN=$(LOCALBIN) go install -mod=readonly sigs.k8s.io/kind@v0.26.0
 
 .PHONY: clean
 clean: 


### PR DESCRIPTION
Previously, the `Makefile` tracked binaries like `protoc-gen-golang-deepcopy`
based on the `./bin/` directory timestamp. This caused unnecessary downloads
whenever files inside the directory were modified, as directory `mtime` updates
on file creation, modification, or deletion.

This change ensures that directory is always created first and is not
used as prerequisite for other files to be downloaded there, thus avoiding
re-downloading them due to the fact that `mtime` of the directory is always
newer than the last downloaded file.

![giphy](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZnhrazhtOWQzeHV6aXVsazI4YXRoOHNmcDB0dHB6czZjd2MyYjJxNiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/edJJXAzQkxHoc/giphy.gif)


## Examples

In both cases `protoc` is updating `mtime` of `bin` and thus making it newer that all the files in this directory.

This triggers remake of all the targets and so downloads of the binaries when the target depend on `$(LOCALBIN)`.

### Before the change

<details>
<summary>$ make --debug=b</summary>

```sh
federation on  master [$] via  v1.23.4 took 14s 
❯ ls -l --time-style=full-iso /home/bartek/code/redhat/ossm/federation/bin        
.rwxr-xr-x@ 6.9M bartek 2024-12-18 19:46:47.277330998 +0100 goimports
.rwxr-xr-x@ 4.7M bartek 2024-12-18 19:46:43.074299515 +0100 protoc
.rwxr-xr-x@ 7.5M bartek 2024-12-18 19:46:44.209308017 +0100 protoc-gen-go
.rwxr-xr-x@ 6.9M bartek 2024-12-18 19:46:45.440317238 +0100 protoc-gen-go-grpc
.rwxr-xr-x@ 6.8M bartek 2024-12-18 19:46:46.271323462 +0100 protoc-gen-golang-deepcopy

federation on  master [$] via  v1.23.4 
❯ ls -l --time-style=full-iso /home/bartek/code/redhat/ossm/federation/ | grep bin
drwxr-xr-x@    - bartek 2024-12-18 19:46:47.274330975 +0100 bin

federation on  master [$] via  v1.23.4 
❯ make --debug=b                                                                  
GNU Make 4.4.1
Built for x86_64-redhat-linux-gnu
Copyright (C) 1988-2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Reading makefiles...
Updating makefiles....
Updating goal targets....
 File 'default' does not exist.
  File 'build' does not exist.
   File 'proto' does not exist.
    Prerequisite '/home/bartek/code/redhat/ossm/federation/bin' is newer than target '/home/bartek/code/redhat/ossm/federation/bin/protoc'.
   Must remake target '/home/bartek/code/redhat/ossm/federation/bin/protoc'.
   Successfully remade target file '/home/bartek/code/redhat/ossm/federation/bin/protoc'.
    Prerequisite '/home/bartek/code/redhat/ossm/federation/bin' is newer than target '/home/bartek/code/redhat/ossm/federation/bin/protoc-gen-go'.
   Must remake target '/home/bartek/code/redhat/ossm/federation/bin/protoc-gen-go'.
   Successfully remade target file '/home/bartek/code/redhat/ossm/federation/bin/protoc-gen-go'.
    Prerequisite '/home/bartek/code/redhat/ossm/federation/bin' is newer than target '/home/bartek/code/redhat/ossm/federation/bin/protoc-gen-go-grpc'.
   Must remake target '/home/bartek/code/redhat/ossm/federation/bin/protoc-gen-go-grpc'.
   Successfully remade target file '/home/bartek/code/redhat/ossm/federation/bin/protoc-gen-go-grpc'.
    Prerequisite '/home/bartek/code/redhat/ossm/federation/bin' is newer than target '/home/bartek/code/redhat/ossm/federation/bin/protoc-gen-golang-deepcopy'.
   Must remake target '/home/bartek/code/redhat/ossm/federation/bin/protoc-gen-golang-deepcopy'.
   Successfully remade target file '/home/bartek/code/redhat/ossm/federation/bin/protoc-gen-golang-deepcopy'.
  Must remake target 'proto'.
  Successfully remade target file 'proto'.
   File 'add-license' does not exist.
  Must remake target 'add-license'.
Adding license to /home/bartek/code/redhat/ossm/federation/internal/api/federation/v1alpha1/exported_service.pb.go
Adding license to /home/bartek/code/redhat/ossm/federation/internal/api/federation/v1alpha1/exported_service_deepcopy.gen.go
  Successfully remade target file 'add-license'.
   File 'fix-imports' does not exist.
  Must remake target 'fix-imports'.
/home/bartek/code/redhat/ossm/federation/bin/goimports -local "github.com/openshift-service-mesh/federation" -w /home/bartek/code/redhat/ossm/federation/
  Successfully remade target file 'fix-imports'.
 Must remake target 'build'.
go get /home/bartek/code/redhat/ossm/federation/...
go build -C /home/bartek/code/redhat/ossm/federation/cmd/federation-controller -o /home/bartek/code/redhat/ossm/federation/out/federation-controller 
 Successfully remade target file 'build'.
  File 'test' does not exist.
 Must remake target 'test'.
go test /home/bartek/code/redhat/ossm/federation/...
?   	github.com/openshift-service-mesh/federation/cmd/federation-controller	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/api/federation/v1alpha1	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/pkg/common	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/pkg/config	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/pkg/kube	[no test files]
ok  	github.com/openshift-service-mesh/federation/internal/pkg/fds	(cached)
?   	github.com/openshift-service-mesh/federation/internal/pkg/networking	[no test files]
ok  	github.com/openshift-service-mesh/federation/internal/pkg/informer	(cached)
ok  	github.com/openshift-service-mesh/federation/internal/pkg/istio	(cached)
?   	github.com/openshift-service-mesh/federation/internal/pkg/openshift	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/pkg/xds	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/pkg/xds/adsc	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/pkg/xds/adss	[no test files]
 Successfully remade target file 'test'.
Must remake target 'default'.
Successfully remade target file 'default'.

```
</details>

### After the change

<details>
<summary>$ make --debug=b</summary>

```sh
federation on  fix-binary-downloads [$!] via  v1.23.4 took 5s
❯ ls -l --time-style=full-iso /home/bartek/code/redhat/ossm/federation/bin
.rwxr-xr-x@ 6.9M bartek 2024-12-18 19:00:59.679367804 +0100 goimports
.rwxr-xr-x@ 4.7M bartek 2024-12-18 19:00:47.890277751 +0100 protoc
.rwxr-xr-x@ 7.5M bartek 2024-12-18 19:00:49.061286696 +0100 protoc-gen-go
.rwxr-xr-x@ 6.9M bartek 2024-12-18 19:00:50.139294931 +0100 protoc-gen-go-grpc
.rwxr-xr-x@ 6.8M bartek 2024-12-18 19:00:50.798299965 +0100 protoc-gen-golang-deepcopy

federation on  fix-binary-downloads [$!] via  v1.23.4
❯ ls -l --time-style=full-iso /home/bartek/code/redhat/ossm/federation/ | grep bin
drwxr-xr-x@    - bartek 2024-12-18 19:00:47.889277743 +0100 bin

federation on  fix-binary-downloads [$!] via  v1.23.4
❯ make --debug=b
GNU Make 4.4.1
Built for x86_64-redhat-linux-gnu
Copyright (C) 1988-2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Reading makefiles...
Updating makefiles....
Updating goal targets....
 File 'default' does not exist.
  File 'build' does not exist.
   File 'proto' does not exist.
  Must remake target 'proto'.
  Successfully remade target file 'proto'.
   File 'add-license' does not exist.
  Must remake target 'add-license'.
Adding license to /home/bartek/code/redhat/ossm/federation/internal/api/federation/v1alpha1/exported_service.pb.go
Adding license to /home/bartek/code/redhat/ossm/federation/internal/api/federation/v1alpha1/exported_service_deepcopy.gen.go
  Successfully remade target file 'add-license'.
   File 'fix-imports' does not exist.
  Must remake target 'fix-imports'.
/home/bartek/code/redhat/ossm/federation/bin/goimports -local "github.com/openshift-service-mesh/federation" -w /home/bartek/code/redhat/ossm/federation/
  Successfully remade target file 'fix-imports'.
 Must remake target 'build'.
go get /home/bartek/code/redhat/ossm/federation/...
go build -C /home/bartek/code/redhat/ossm/federation/cmd/federation-controller -o /home/bartek/code/redhat/ossm/federation/out/federation-controller
 Successfully remade target file 'build'.
  File 'test' does not exist.
 Must remake target 'test'.
go test /home/bartek/code/redhat/ossm/federation/...
?   	github.com/openshift-service-mesh/federation/cmd/federation-controller	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/api/federation/v1alpha1	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/pkg/common	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/pkg/config	[no test files]
ok  	github.com/openshift-service-mesh/federation/internal/pkg/fds	(cached)
?   	github.com/openshift-service-mesh/federation/internal/pkg/kube	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/pkg/openshift	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/pkg/xds/adsc	[no test files]
ok  	github.com/openshift-service-mesh/federation/internal/pkg/informer	(cached)
?   	github.com/openshift-service-mesh/federation/internal/pkg/xds	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/pkg/networking	[no test files]
?   	github.com/openshift-service-mesh/federation/internal/pkg/xds/adss	[no test files]
ok  	github.com/openshift-service-mesh/federation/internal/pkg/istio	(cached)
 Successfully remade target file 'test'.
Must remake target 'default'.
Successfully remade target file 'default'.
```

</details>

