### PR TITLE
chore(make): simplifies build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PROTOC_GEN_GRPC := $(LOCALBIN)/protoc-gen-go-grpc
 PROTOC_GEN_DEEPCOPY := $(LOCALBIN)/protoc-gen-golang-deepcopy
 
 .PHONY: default
-default: build test
+default: build add-license fix-imports test
 
 .PHONY: help
 help:
@@ -25,7 +25,7 @@ help:
 
 EXTRA_BUILD_ARGS?=
 .PHONY: build
-build: proto add-license fix-imports ## Builds the project
+build: proto ## Builds the project
 	go get $(PROJECT_DIR)/...
 	go build -C $(PROJECT_DIR)/cmd/federation-controller -o $(PROJECT_DIR)/$(OUT_DIR)/federation-controller $(EXTRA_BUILD_ARGS)
 


### PR DESCRIPTION
Aims to make `build` as lean as possible with the only goal to produce
the binary. At the same time moving license and import fixes to chain of
default targets.

Without this change there's always license added after regenerating
protobuf go stubs. When using tools such as air-verse/air to rebuild the
project on code changes this leads to unnecessary build loops, as one
change triggers `make build` process which leads to watch reacting on
licenses added to source files and re-triggering the build.

> [!NOTE]
> This can be obviously solved by simplifying rebuild command in the tool itself by
> swapping it from `make build` to `go build` but I thought we could
> simplify it on the `Makefile` level.
