### PR TITLE
feat(make): replaces `go get` with `deps` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,15 @@ help:
 
 ##@ Build
 
+.PHONY: deps
+deps: ## Downloads required dependencies
+	go mod tidy
+	go mod download
+
+
 EXTRA_BUILD_ARGS?=
 .PHONY: build
-build: proto ## Builds the project
-	go get $(PROJECT_DIR)/...
+build: deps proto ## Builds the project
 	go build -C $(PROJECT_DIR)/cmd/federation-controller -o $(PROJECT_DIR)/$(OUT_DIR)/federation-controller $(EXTRA_BUILD_ARGS)
 
 .PHONY: test
@@ -80,7 +85,7 @@ e2e: kind-clusters ## Runs end-to-end tests against KinD clusters
 			--istio.test.kube.networkTopology=0:east-network,1:west-network\
 			--istio.test.onlyWorkloads=standard); \
 
-##@ Tooling
+## Tooling
 
 $(shell mkdir -p $(LOCALBIN))
 


### PR DESCRIPTION
`go get ./...` is unnecessary with Go modules, can cause unwanted updates, and is only relevant for legacy projects.

This PR introduces new `deps` target that relies on `go mod` commands.