### PR TITLE
fix(make): runs all e2e suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,8 @@ e2e: kind-clusters ## Runs end-to-end tests against KinD clusters
 			--istio.test.tag=$(ISTIO_VERSION)\
 			--istio.test.kube.config=$(PROJECT_DIR)/test/east.kubeconfig,$(PROJECT_DIR)/test/west.kubeconfig\
 			--istio.test.kube.networkTopology=0:east-network,1:west-network\
-			--istio.test.onlyWorkloads=standard); \
+			--istio.test.onlyWorkloads=standard; \
+	)
 
 ## Tooling
 


### PR DESCRIPTION
One of my previous PRs (#109) introduces nicely hidden bug which
essentially always result in running first suite from the list of
TEST_SUITES.

This change brings back the proper way of wrapping `foreach` in an eval
clause.
