### PR TITLE
chore(make): ensures protoc generated code is correctly formatted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,10 @@ clean:
 
 ##@ Code Gen
 
-$(PROTOBUF_GEN): $(PROTOBUF_API_SRC) $(PROTOC) $(PROTOC_GEN_GO) $(PROTOC_GEN_GRPC) $(PROTOC_GEN_DEEPCOPY) ## Generates Go files from protobuf-based API files
+$(PROTOBUF_GEN): $(PROTOBUF_API_SRC) $(PROTOC) $(PROTOC_GEN_GO) $(PROTOC_GEN_GRPC) $(PROTOC_GEN_DEEPCOPY) $(GOIMPORTS) ## Generates Go files from protobuf-based API files
 	@PATH=$(LOCALBIN):$$PATH $(PROTOC) --proto_path=$(PROTOBUF_API_DIR) --go_out=$(API_GEN_DIR) --go-grpc_out=$(API_GEN_DIR) --golang-deepcopy_out=:$(API_GEN_DIR) $(PROTOBUF_API_DIR)/**/*.proto
+	@$(MAKE) add-license
+	@$(GOIMPORTS) -local "github.com/openshift-service-mesh/federation" -w $(API_GEN_DIR)/
 
 $(CRD_GEN): $(CRD_SRC) $(CONTROLLER_GEN) ## Generates CRDs and DeepCopy method implementations.
 	$(CONTROLLER_GEN) paths="$(CRD_SRC_DIR)/..." \


### PR DESCRIPTION
`protoc`, while regenerating the go files is removing the license header
and changes imports order.

With this change we add the license back and fix imports after regenerating
protobuf sources, so it's always consistent.
