### PR TITLE
fix(fds): simplifies sync logic

### DIFF
--- a/internal/pkg/xds/adss/adss_handler.go
+++ b/internal/pkg/xds/adss/adss_handler.go
@@ -48,7 +48,6 @@ type adsServer struct {
 	handlers         map[string]RequestHandler
 	subscribers      sync.Map
 	nextSubscriberID atomic.Uint64
-	onNewSubscriber  func()
 }
 
 // subscriber represents a client that is subscribed to XDS resources.
@@ -72,9 +71,6 @@ func (adss *adsServer) StreamAggregatedResources(downstream DiscoveryStream) err
 
 	adss.subscribers.Store(sub.id, sub)
 
-	if adss.onNewSubscriber != nil {
-		adss.onNewSubscriber()
-	}
 	go adss.recvFromStream(int64(sub.id), downstream)
 
 	<-ctx.Done()

--- a/internal/pkg/xds/adss/grpc_server.go
+++ b/internal/pkg/xds/adss/grpc_server.go
@@ -31,15 +31,14 @@ type Server struct {
 	pushRequests <-chan xds.PushRequest
 }
 
-func NewServer(pushRequests <-chan xds.PushRequest, onNewSubscriber func(), handlers ...RequestHandler) *Server {
+func NewServer(pushRequests <-chan xds.PushRequest, handlers ...RequestHandler) *Server {
 	grpcServer := grpc.NewServer()
 	handlerMap := make(map[string]RequestHandler)
 	for _, g := range handlers {
 		handlerMap[g.GetTypeUrl()] = g
 	}
 	ads := &adsServer{
-		handlers:        handlerMap,
-		onNewSubscriber: onNewSubscriber,
+		handlers: handlerMap,
 	}
 
 	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, ads)


### PR DESCRIPTION
My understanding of the current client-server flow is as follows:

- client connects to the server
- it requests push of predefined types (ExportedSvc) as initial push
  request - SotW
- on subscriber(client) connect, server does another SotW push

Not only we are sending the same data twice, but we also need to make
sure that handlers we define are aligned with initial push requests.
If we add new handler, we need to explictly define it as part of
initial push. It also needs to be defined (again) in onSubscribe
on the FDS server side.

This PR moves the initial sync responsibility to the client, ensuring
each handler automatically requests the data it needs. This avoids
redundant pushes and reduces code duplication.

Signed-off-by: bartoszmajsak <bartosz.majsak@gmail.com>
