### PR TITLE
chore(fds): renames peer to remote

### DIFF
--- a/cmd/federation-controller/main.go
+++ b/cmd/federation-controller/main.go
@@ -307,7 +307,7 @@ func startFDSClient(ctx context.Context, remote config.Remote, meshConfigPushReq
 	}
 
 	fdsClient, errNew := adsc.New(&adsc.ADSCConfig{
-		PeerName:      remote.Name,
+		RemoteName:    remote.Name,
 		DiscoveryAddr: discoveryAddr,
 		Authority:     remote.ServiceFQDN(),
 		Handlers: map[string]adsc.ResponseHandler{

--- a/internal/pkg/xds/adsc/adsc.go
+++ b/internal/pkg/xds/adsc/adsc.go
@@ -35,7 +35,7 @@ const (
 )
 
 type ADSCConfig struct {
-	PeerName       string
+	RemoteName     string
 	DiscoveryAddr  string
 	Authority      string
 	Handlers       map[string]ResponseHandler
@@ -55,7 +55,7 @@ func New(opts *ADSCConfig) (*ADSC, error) {
 	}
 	adsc := &ADSC{
 		cfg: opts,
-		log: istiolog.RegisterScope("adsc", "Aggregated Discovery Service Client").WithLabels("peer", opts.PeerName),
+		log: istiolog.RegisterScope("adsc", "Aggregated Discovery Service Client").WithLabels("peer", opts.RemoteName),
 	}
 	if err := adsc.dial(); err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ loop:
 			}
 			a.log.Infof("received response for %s: %v", msg.TypeUrl, msg.Resources)
 			if handler, found := a.cfg.Handlers[msg.TypeUrl]; found {
-				if err := handler.Handle(a.cfg.PeerName, msg.Resources); err != nil {
+				if err := handler.Handle(a.cfg.RemoteName, msg.Resources); err != nil {
 					a.log.Infof("error handling resource %s: %v", msg.TypeUrl, err)
 				}
 			} else {


### PR DESCRIPTION
FDS Client keeps remote mesh name which was confusingly named PeerName.
This PR changes this name so we stick to the same terminology as in
upcoming CRDs.

The `config.meshPeers` is going away so it wasn't reworked, as that would
require splitting struct to local/remotes.

Signed-off-by: bartoszmajsak <bartosz.majsak@gmail.com>
