### PR TITLE
chore: renames err vars to follow conventions

### DIFF
--- a/cmd/federation-controller/main.go
+++ b/cmd/federation-controller/main.go
@@ -314,7 +314,7 @@ func startFDSClient(ctx context.Context, remote config.Remote, meshConfigPushReq
 		discoveryAddr = fmt.Sprintf("%s:%d", remote.Addresses[0], remote.ServicePort())
 	}
 
-	fdsClient, errNew := adsc.New(&adsc.ADSCConfig{
+	fdsClient, errClient := adsc.New(&adsc.ADSCConfig{
 		RemoteName:    remote.Name,
 		DiscoveryAddr: discoveryAddr,
 		Authority:     remote.ServiceFQDN(),
@@ -323,16 +323,16 @@ func startFDSClient(ctx context.Context, remote config.Remote, meshConfigPushReq
 		},
 		ReconnectDelay: reconnectDelay,
 	})
-	if errNew != nil {
-		log.Fatalf("failed to create FDS client: %v", errNew)
+	if errClient != nil {
+		log.Fatalf("failed to create FDS client: %v", errClient)
 	}
 
 	go func() {
 		if errRun := fdsClient.Run(ctx); errRun != nil {
 			log.Errorf("failed to start FDS client, will reconnect in %s: %v", reconnectDelay, errRun)
 			time.AfterFunc(reconnectDelay, func() {
-				if ctxErr := ctx.Err(); ctxErr != nil {
-					log.Infof("Parent ctx is done: %v", ctxErr)
+				if errCtx := ctx.Err(); errCtx != nil {
+					log.Infof("Parent ctx is done: %v", errCtx)
 					return
 				}
 

--- a/internal/pkg/xds/adsc/adsc.go
+++ b/internal/pkg/xds/adsc/adsc.go
@@ -74,8 +74,8 @@ func (a *ADSC) Run(ctx context.Context) error {
 
 	for k, _ := range a.cfg.Handlers {
 		discoveryRequest := &discovery.DiscoveryRequest{TypeUrl: k}
-		if sendErr := a.Send(discoveryRequest); sendErr != nil {
-			a.log.Errorf("[%s] failed requesting initial discovery sync: %+v", k, sendErr)
+		if errSend := a.Send(discoveryRequest); errSend != nil {
+			a.log.Errorf("[%s] failed requesting initial discovery sync: %+v", k, errSend)
 		}
 	}
 
@@ -89,8 +89,8 @@ func (a *ADSC) Restart(ctx context.Context) {
 	if err := a.Run(ctx); err != nil {
 		a.log.Errorf("failed to connect to ADS server %s, will reconnect in %s: %v", a.cfg.DiscoveryAddr, a.cfg.ReconnectDelay, err)
 		time.AfterFunc(a.cfg.ReconnectDelay, func() {
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				a.log.Infof("Parent ctx is done: %v", ctxErr)
+			if errCtx := ctx.Err(); errCtx != nil {
+				a.log.Infof("Parent ctx is done: %v", errCtx)
 				return
 			}
 


### PR DESCRIPTION
Adhering to [golang conventions](https://go.dev/wiki/Errors#naming) will make the code easier to read for everyone and simplify snowballing when we introduce linters.

This PR renames every error variable that users `err` as suffix to be its prefix instead.

Signed-off-by: bartoszmajsak <bartosz.majsak@gmail.com>
