### PR TITLE
chore(ctrl): removes explicit reference to runtime.Scheme

### DIFF
--- a/cmd/federation-controller/main.go
+++ b/cmd/federation-controller/main.go
@@ -138,14 +138,12 @@ func main() {
 
 	if err = (&controller.MeshFederationReconciler{
 		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		log.Errorf("unable to create controller for MeshFederation custom resource: %s", err)
 		os.Exit(1)
 	}
 	if err = (&controller.FederatedServiceReconciler{
 		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		log.Errorf("unable to create FederatedService controller: %s", err)
 		os.Exit(1)

--- a/internal/controller/federatedservice_controller.go
+++ b/internal/controller/federatedservice_controller.go
@@ -17,7 +17,6 @@ package controller
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -28,7 +27,6 @@ import (
 // FederatedServiceReconciler reconciles a FederatedService object
 type FederatedServiceReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
 }
 
 // +kubebuilder:rbac:groups=federation.openshift-service-mesh.io,resources=federatedservices,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/meshfederation_controller.go
+++ b/internal/controller/meshfederation_controller.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/openshift-service-mesh/federation/api/v1alpha1"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -28,7 +27,6 @@ import (
 // MeshFederationReconciler reconciles a MeshFederation object
 type MeshFederationReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
 }
 
 // +kubebuilder:rbac:groups=federation.openshift-service-mesh.io,resources=meshfederations,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
It seems that scaffolded code where both `client.Client` and
`runtime.Scheme` are fields of generated controller struct is based on old
version of `controller-runtime` [1].

Since `v0.0.7` [2] `client.Client` interface exposes `GetSchema` func, so
we can rely on it instead. It simplifies the code and ensures we are
always have the same `runtime.Scheme` as the client we use to interact
with `kube-apiserver`.

This PR removes direct reference to `runtime.Scheme` from controllers.
Scheme can be accessed using `ctrl.Client.GetScheme()` instead. We might
need it when using `SetControllerReference` or `EnqueueRequestForOwner`.

[1] [controller-runtime v0.6.0 Client](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.6.0/pkg/client/interfaces.go#L104-L108)

[2] [controller-runtime v0.0.7
Client](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.7.0/pkg/client/interfaces.go#L100-L109)

Signed-off-by: bartoszmajsak <bartosz.majsak@gmail.com>
