### PR TITLE
feat(build): replaces goimports with gci

### DIFF
--- a/cmd/federation-controller/main.go
+++ b/cmd/federation-controller/main.go
@@ -34,11 +34,6 @@ import (
 	"k8s.io/client-go/informers"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	v1 "k8s.io/client-go/listers/core/v1"
-
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
 	// +kubebuilder:scaffold:imports
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -58,6 +53,10 @@ import (
 	"github.com/openshift-service-mesh/federation/internal/pkg/xds"
 	"github.com/openshift-service-mesh/federation/internal/pkg/xds/adsc"
 	"github.com/openshift-service-mesh/federation/internal/pkg/xds/adss"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 var (

--- a/internal/controller/meshfederation_controller.go
+++ b/internal/controller/meshfederation_controller.go
@@ -17,11 +17,11 @@ package controller
 import (
 	"context"
 
-	"github.com/openshift-service-mesh/federation/api/v1alpha1"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/openshift-service-mesh/federation/api/v1alpha1"
 )
 
 // MeshFederationReconciler reconciles a MeshFederation object

--- a/internal/pkg/config/parse.go
+++ b/internal/pkg/config/parse.go
@@ -15,10 +15,9 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
-
-	"encoding/json"
 )
 
 // ParseArgs parses input arguments passed in JSON format to the config.Federation struct.

--- a/internal/pkg/fds/imported_service_store.go
+++ b/internal/pkg/fds/imported_service_store.go
@@ -17,9 +17,8 @@ package fds
 import (
 	"sync"
 
-	"github.com/openshift-service-mesh/federation/internal/pkg/config"
-
 	"github.com/openshift-service-mesh/federation/internal/api/federation/v1alpha1"
+	"github.com/openshift-service-mesh/federation/internal/pkg/config"
 )
 
 // ImportedServiceStore is a thread-safe wrapper for current state of imported services

--- a/test/e2e/scenarios/remote_dns_name/main_test.go
+++ b/test/e2e/scenarios/remote_dns_name/main_test.go
@@ -20,12 +20,11 @@ package remote_dns_name
 import (
 	"testing"
 
+	"istio.io/istio/pkg/test/framework"
+
 	"github.com/openshift-service-mesh/federation/test/e2e"
 	"github.com/openshift-service-mesh/federation/test/e2e/setup"
-
 	"github.com/openshift-service-mesh/federation/test/e2e/setup/coredns"
-
-	"istio.io/istio/pkg/test/framework"
 )
 
 func TestMain(m *testing.M) {

--- a/test/e2e/scenarios/remote_ip/main_test.go
+++ b/test/e2e/scenarios/remote_ip/main_test.go
@@ -20,10 +20,10 @@ package remote_ip
 import (
 	"testing"
 
+	"istio.io/istio/pkg/test/framework"
+
 	"github.com/openshift-service-mesh/federation/test/e2e"
 	"github.com/openshift-service-mesh/federation/test/e2e/setup"
-
-	"istio.io/istio/pkg/test/framework"
 )
 
 func TestMain(m *testing.M) {

--- a/test/e2e/scenarios/spire/main_test.go
+++ b/test/e2e/scenarios/spire/main_test.go
@@ -20,10 +20,10 @@ package spire
 import (
 	"testing"
 
+	"istio.io/istio/pkg/test/framework"
+
 	"github.com/openshift-service-mesh/federation/test/e2e"
 	"github.com/openshift-service-mesh/federation/test/e2e/setup"
-
-	"istio.io/istio/pkg/test/framework"
 )
 
 func TestMain(m *testing.M) {

--- a/test/e2e/scenarios/spire/setup.go
+++ b/test/e2e/scenarios/spire/setup.go
@@ -23,13 +23,13 @@ import (
 	"sync"
 	"text/template"
 
-	"github.com/openshift-service-mesh/federation/test"
-	"github.com/openshift-service-mesh/federation/test/e2e/setup"
-
 	"golang.org/x/sync/errgroup"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
+
+	"github.com/openshift-service-mesh/federation/test"
+	"github.com/openshift-service-mesh/federation/test/e2e/setup"
 )
 
 var spireComponents = []string{

--- a/test/e2e/setup/cluster_cmds.go
+++ b/test/e2e/setup/cluster_cmds.go
@@ -31,7 +31,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift-service-mesh/federation/test"

--- a/test/e2e/setup/coredns/patch.go
+++ b/test/e2e/setup/coredns/patch.go
@@ -23,14 +23,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift-service-mesh/federation/test/e2e/setup"
-
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift-service-mesh/federation/test/e2e/setup"
 )
 
 var originalCorefilesPerCluster = map[string]string{}

--- a/test/e2e/setup/federation.go
+++ b/test/e2e/setup/federation.go
@@ -21,9 +21,8 @@ import (
 	"fmt"
 
 	"golang.org/x/sync/errgroup"
-	"istio.io/istio/pkg/test/scopes"
-
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/scopes"
 )
 
 func InstallOrUpgradeFederationControllers(options ...CtrlOption) resource.SetupFn {

--- a/test/e2e/traffic_tests.go
+++ b/test/e2e/traffic_tests.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openshift-service-mesh/federation/test/e2e/setup"
-
 	"google.golang.org/grpc/codes"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
@@ -31,6 +29,8 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/check"
 	"istio.io/istio/pkg/test/framework/components/echo/common/ports"
 	"istio.io/istio/pkg/test/framework/components/echo/match"
+
+	"github.com/openshift-service-mesh/federation/test/e2e/setup"
 )
 
 type echoTestCase struct {


### PR DESCRIPTION
While working on #159 my IDE moved local imports around
and `goimports` didn't reformat it properly. It would be good to have
clear rules for grouping and separating libraries we rely on that are
applied deterministically. It seems that `goimports` is fairly limited
and can handle only sorting and basic grouping. This can lead to noise
in PRs which we shouldn't bother about.

This PR changes `fix-imports` target to use `gci` tool instead. This
tool offers more granular control over group definitions so we can
ensure consistency across the codebase.

> [!NOTE]
> Even though `gci` is part of `golangci-lint` I deliberately added it
> as a standalone tool. Introducing the latter is a bigger task which I
> hope I can soon contribute.

Signed-off-by: bartoszmajsak <bartosz.majsak@gmail.com>
