### PR TITLE
fix(api): changes scope of CRs to Namespaced

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -10,6 +10,7 @@ repo: github.com/openshift-service-mesh/federation
 resources:
 - api:
     crdVersion: v1
+    namespaced: true
   controller: true
   domain: openshift-service-mesh.io
   group: federation

--- a/api/v1alpha1/federatedservice_types.go
+++ b/api/v1alpha1/federatedservice_types.go
@@ -38,6 +38,7 @@ type FederatedServiceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Namespaced
 
 // FederatedService is the Schema for the federatedservices API.
 type FederatedService struct {

--- a/api/v1alpha1/meshfederation_types.go
+++ b/api/v1alpha1/meshfederation_types.go
@@ -38,7 +38,7 @@ type MeshFederationStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Namespaced
 
 // MeshFederation is the Schema for the meshfederations API.
 type MeshFederation struct {

--- a/chart/crds/federation.openshift-service-mesh.io_meshfederations.yaml
+++ b/chart/crds/federation.openshift-service-mesh.io_meshfederations.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: MeshFederationList
     plural: meshfederations
     singular: meshfederation
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1alpha1
     schema:


### PR DESCRIPTION
Current assumption is that we have all our resources namespaced.

This PR changes the scope of existing resources to be namespaced.

Signed-off-by: bartoszmajsak <bartosz.majsak@gmail.com>
