### PR TITLE
feat(ctlr): introduces constructor function

### DIFF
--- a/cmd/federation-controller/main.go
+++ b/cmd/federation-controller/main.go
@@ -42,7 +42,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/openshift-service-mesh/federation/api/v1alpha1"
-	"github.com/openshift-service-mesh/federation/internal/controller"
+	"github.com/openshift-service-mesh/federation/internal/controller/federatedservice"
+	"github.com/openshift-service-mesh/federation/internal/controller/meshfederation"
 	"github.com/openshift-service-mesh/federation/internal/pkg/config"
 	"github.com/openshift-service-mesh/federation/internal/pkg/fds"
 	"github.com/openshift-service-mesh/federation/internal/pkg/informer"
@@ -156,15 +157,11 @@ func runCtrls(ctx context.Context, cancel context.CancelFunc) {
 		os.Exit(1)
 	}
 
-	if err = (&controller.MeshFederationReconciler{
-		Client: mgr.GetClient(),
-	}).SetupWithManager(mgr); err != nil {
+	if err = meshfederation.NewReconciler(mgr.GetClient()).SetupWithManager(mgr); err != nil {
 		log.Errorf("unable to create controller for MeshFederation custom resource: %s", err)
 		os.Exit(1)
 	}
-	if err = (&controller.FederatedServiceReconciler{
-		Client: mgr.GetClient(),
-	}).SetupWithManager(mgr); err != nil {
+	if err = federatedservice.NewReconciler(mgr.GetClient()).SetupWithManager(mgr); err != nil {
 		log.Errorf("unable to create FederatedService controller: %s", err)
 		os.Exit(1)
 	}

--- a/internal/controller/federatedservice/federatedservice_controller.go
+++ b/internal/controller/federatedservice/federatedservice_controller.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controller
+package federatedservice
 
 import (
 	"context"
@@ -24,31 +24,26 @@ import (
 	federationv1alpha1 "github.com/openshift-service-mesh/federation/api/v1alpha1"
 )
 
-// FederatedServiceReconciler reconciles a FederatedService object
-type FederatedServiceReconciler struct {
-	client.Client
-}
-
 // +kubebuilder:rbac:groups=federation.openshift-service-mesh.io,resources=federatedservices,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=federation.openshift-service-mesh.io,resources=federatedservices/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=federation.openshift-service-mesh.io,resources=federatedservices/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the FederatedService object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.1/pkg/reconcile
-func (r *FederatedServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+// Reconciler ensure that cluster is configured according to the spec defined in FederatedService
+type Reconciler struct {
+	client.Client
+}
+
+func NewReconciler(c client.Client) *Reconciler {
+	return &Reconciler{Client: c}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log.FromContext(ctx).Info("Reconciling object", "name", req.Name, "namespace", req.Namespace)
 	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *FederatedServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&federationv1alpha1.FederatedService{}).
 		Complete(r)

--- a/internal/controller/meshfederation/meshfederation_controller.go
+++ b/internal/controller/meshfederation/meshfederation_controller.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controller
+package meshfederation
 
 import (
 	"context"
@@ -24,31 +24,26 @@ import (
 	"github.com/openshift-service-mesh/federation/api/v1alpha1"
 )
 
-// MeshFederationReconciler reconciles a MeshFederation object
-type MeshFederationReconciler struct {
-	client.Client
-}
-
 // +kubebuilder:rbac:groups=federation.openshift-service-mesh.io,resources=meshfederations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=federation.openshift-service-mesh.io,resources=meshfederations/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=federation.openshift-service-mesh.io,resources=meshfederations/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the MeshFederation object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.1/pkg/reconcile
-func (r *MeshFederationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+// Reconciler ensure that cluster is configured according to the spec defined in MeshFederation object.
+type Reconciler struct {
+	client.Client
+}
+
+func NewReconciler(c client.Client) *Reconciler {
+	return &Reconciler{Client: c}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log.FromContext(ctx).Info("Reconciling object", "namespace", req.Namespace)
 	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *MeshFederationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.MeshFederation{}).
 		Complete(r)


### PR DESCRIPTION
Constructor function ensures that each controller instance
is created with all required objects.

This PR introduces these functions to existing controllers and move each
of controllers to their own packages. This way we can keep all related
logic in a single, dedicated place instead  mixing them in a single pkg
`controller`. It also simplifies the approach of using constructor
functions. Now we can call `meshfederation.NewReconciler` or
`federatedservice.NewReconciler` accordingly.

Signed-off-by: bartoszmajsak <bartosz.majsak@gmail.com>
