### PR TITLE
feat(ctrl): predicate on finalizer change

### DIFF
--- a/internal/controller/meshfederation/meshfederation_controller.go
+++ b/internal/controller/meshfederation/meshfederation_controller.go
@@ -20,8 +20,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/openshift-service-mesh/federation/api/v1alpha1"
+	"github.com/openshift-service-mesh/federation/internal/controller"
 )
 
 // +kubebuilder:rbac:groups=federation.openshift-service-mesh.io,resources=meshfederations,verbs=get;list;watch;create;update;patch;delete
@@ -45,6 +47,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("mesh-federation-ctrl").
 		For(&v1alpha1.MeshFederation{}).
+		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, controller.FinalizerChanged())).
 		Complete(r)
 }

--- a/internal/controller/predicate.go
+++ b/internal/controller/predicate.go
@@ -1,0 +1,30 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"reflect"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+func FinalizerChanged() predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return !reflect.DeepEqual(e.ObjectNew.GetFinalizers(), e.ObjectOld.GetFinalizers())
+		},
+	}
+}


### PR DESCRIPTION
`finalizer.Handler` introduced in #164 is expected to retrigger
reconcile when finalizer is added for the first time. This ensures that
given controller adds its cleanup hook to the resource as soon as
possible.

However adding finalizer does not increase generation of the resource,
therefore using `WithEventFilter(predicate.GenerationChangedPredicate{})`
will not cause another reconcile.

This PR brings `FinalizerChanged` predicate which can be combined:

```golang
WithEventFilter(
	predicate.Or(
		predicate.GenerationChangedPredicate{},
		FinalizerChanged(),
	),
).
```

and it will trigger reconciliation on the finalizer change.

Signed-off-by: bartoszmajsak <bartosz.majsak@gmail.com>
