### PR TITLE
docs: update samples for OpenShift

### DIFF
--- a/examples/openshift/east-mesh.yaml
+++ b/examples/openshift/east-mesh.yaml
@@ -1,17 +1,17 @@
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: IstioCNI
 metadata:
   name: default
 spec:
-  version: v1.23.0
+  version: v1.24.3
   namespace: istio-cni
 ---
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default
 spec:
-  version: v1.23.0
+  version: v1.24.3
   namespace: istio-system
   updateStrategy:
     type: InPlace
@@ -30,5 +30,4 @@ spec:
       network: east-network
     pilot:
       env:
-        ROOT_CA_DIR: /etc/cacerts
         ENABLE_NATIVE_SIDECARS: "true"

--- a/examples/openshift/west-mesh.yaml
+++ b/examples/openshift/west-mesh.yaml
@@ -1,17 +1,17 @@
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: IstioCNI
 metadata:
   name: default
 spec:
-  version: v1.23.0
+  version: v1.24.3
   namespace: istio-cni
 ---
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default
 spec:
-  version: v1.23.0
+  version: v1.24.3
   namespace: istio-system
   updateStrategy:
     type: InPlace
@@ -30,5 +30,4 @@ spec:
       network: west-network
     pilot:
       env:
-        ROOT_CA_DIR: /etc/cacerts
         ENABLE_NATIVE_SIDECARS: "true"


### PR DESCRIPTION
Samples for OpenShift worked only with the operator 3.0.0-tp.2, which is no longer available.