### PR TITLE
docs/test: disable OIDC discovery provider

### DIFF
--- a/examples/spire/east/values.yaml
+++ b/examples/spire/east/values.yaml
@@ -34,6 +34,8 @@ spire-server:
               security.istio.io/tlsMode: istio
           federatesWith:
           - west.local
+        oidc-discovery-provider:
+          enabled: false
         test-keys:
           enabled: false
 
@@ -45,6 +47,4 @@ spire-agent:
     defaultAllBundlesName: ROOTCA
 
 spiffe-oidc-discovery-provider:
-  tls:
-    spire:
-      enabled: false
+  enabled: false

--- a/examples/spire/west/values.yaml
+++ b/examples/spire/west/values.yaml
@@ -35,6 +35,8 @@ spire-server:
               security.istio.io/tlsMode: istio
           federatesWith:
           - east.local
+        oidc-discovery-provider:
+          enabled: false
         test-keys:
           enabled: false
 
@@ -46,6 +48,4 @@ spire-agent:
     defaultAllBundlesName: ROOTCA
 
 spiffe-oidc-discovery-provider:
-  tls:
-    spire:
-      enabled: false
+  enabled: false

--- a/test/e2e/scenarios/spire/setup.go
+++ b/test/e2e/scenarios/spire/setup.go
@@ -35,7 +35,6 @@ import (
 var spireComponents = []string{
 	"daemonset/spire-spiffe-csi-driver",
 	"statefulset/spire-server",
-	"deployment/spire-spiffe-oidc-discovery-provider",
 	"daemonset/spire-agent",
 }
 

--- a/test/testdata/spire/central.yaml
+++ b/test/testdata/spire/central.yaml
@@ -37,6 +37,8 @@ spire-server:
           federatesWith:
           - east.local
           - west.local
+        oidc-discovery-provider:
+          enabled: false
         test-keys:
           enabled: false
 
@@ -48,6 +50,4 @@ spire-agent:
     defaultAllBundlesName: ROOTCA
 
 spiffe-oidc-discovery-provider:
-  tls:
-    spire:
-      enabled: false
+  enabled: false

--- a/test/testdata/spire/east.yaml
+++ b/test/testdata/spire/east.yaml
@@ -36,6 +36,8 @@ spire-server:
           federatesWith:
           - west.local
           - central.local
+        oidc-discovery-provider:
+          enabled: false
         test-keys:
           enabled: false
 
@@ -47,6 +49,4 @@ spire-agent:
     defaultAllBundlesName: ROOTCA
 
 spiffe-oidc-discovery-provider:
-  tls:
-    spire:
-      enabled: false
+  enabled: false

--- a/test/testdata/spire/west.yaml
+++ b/test/testdata/spire/west.yaml
@@ -37,6 +37,8 @@ spire-server:
           federatesWith:
           - east.local
           - central.local
+        oidc-discovery-provider:
+          enabled: false
         test-keys:
           enabled: false
 
@@ -48,6 +50,4 @@ spire-agent:
     defaultAllBundlesName: ROOTCA
 
 spiffe-oidc-discovery-provider:
-  tls:
-    spire:
-      enabled: false
+  enabled: false


### PR DESCRIPTION
We never needed OIDC discovery provider, because we don't use JWT-SVID to authenticate workloads, so we can disable this service to make tests and example deployments faster.